### PR TITLE
do not show an outdated version for core snap and manifest file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image 
 
 # workaround for LP: #1588336, needs to be bumped along
 # with the snapcraft.yaml version for now
-VERSION := 16.04.1
+VERSION := 16-2
 
 #ifneq ($(shell grep $(RELEASE)-proposed /etc/apt/sources.list),)
 #ENV += PROPOSED=1

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: core
-version: 16.04.1
+version: 16-2
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
bump version strings in Makefile and snapcraft.yaml (16.04.1 is wrong, the new versioning can not be implemented until https://launchpad.net/bugs/1611439 is fixed, as an interim use 16-2 as version everywhere)