### PR TITLE
add snappy-dev/edge2 ppa to allow 2.23 in a ppa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DPKG_ARCH := $(shell dpkg --print-architecture)
 RELEASE := $(shell lsb_release -c -s)
-ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image snappy-dev/edge' IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
+ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image snappy-dev/edge snappy-dev/edge2' IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
 
 # workaround for LP: #1588336, needs to be bumped along
 # with the snapcraft.yaml version for now


### PR DESCRIPTION
This temporarily adds a new snappy-dev/edge2 PPA to allow uploading 2.23 (which already was uploaded to the other ppas because it was almost released but then wasn't).  