### PR TITLE
undo adding of ppa:snappy-dev/edge2 again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DPKG_ARCH := $(shell dpkg --print-architecture)
 RELEASE := $(shell lsb_release -c -s)
-ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image snappy-dev/edge snappy-dev/edge2' IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
+ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image snappy-dev/edge' IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
 
 # workaround for LP: #1588336, needs to be bumped along
 # with the snapcraft.yaml version for now


### PR DESCRIPTION
This was only needed briefly for 2.23 because that version already exited in the existing PPAs (because it was almost released but then we discovered some issues in testing and it got postponed).