### PR TITLE
configure: add support for pi2 config.txt updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: C
+language: python
+python:
+  - "3.5"
 dist: xenial
 install:
   - sudo apt install shellcheck
@@ -16,5 +18,5 @@ install:
   - sudo mkdir -p xenial-test-chroot/build
   - sudo cp -a Makefile snapcraft.yaml hooks live-build xenial-test-chroot/build
 script:
-  - sudo chroot xenial-test-chroot make check
+  - make check
   - sudo chroot xenial-test-chroot sh -c 'mount -t proc proc /proc; mount -t sysfs sys /sys; cd build; snapcraft'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
   - sudo mkdir -p xenial-test-chroot/build
   - sudo cp -a Makefile snapcraft.yaml hooks live-build xenial-test-chroot/build
 script:
-  - make check
+  - sudo chroot xenial-test-chroot make check
   - sudo chroot xenial-test-chroot sh -c 'mount -t proc proc /proc; mount -t sysfs sys /sys; cd build; snapcraft'

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ check:
 	# exlucde "useless cat" from checks, while useless also makes
 	# some things more readable
 	shellcheck -e SC2002 hooks/* live-build/hooks/*
-
+	python3 -m unittest

--- a/hooks/configure
+++ b/hooks/configure
@@ -75,7 +75,7 @@ switch_service() {
 }
 
 update_pi_config_value() {
-    path="/boot/uboot/config.txt"
+    path="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
     k="$1"
     v="$2"
 
@@ -84,7 +84,7 @@ update_pi_config_value() {
         sed -i -e "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
     else
         # non-empty - set an option
-        if grep "$path" "^[ \t#]*${k}="; then
+        if grep -q "^[ \t#]*${k}=" "$path"; then
             sed -i -e "s/^[ \t#]*${k}=.*/$k=$v/" "$path"
         else
             echo "$k=$v" >> "$path"
@@ -109,8 +109,6 @@ PI_CONFIG_KEYS="disable_overscan framebuffer_width framebuffer_height
  overscan_top overscan_bottom overscan_scale display_rotate hdmi_group
  hdmi_mode hdmi_drive avoid_warnings gpu_mem_256 gpu_mem_512 gpu_mem"
 for key in $PI_CONFIG_KEYS; do
-    value=$(snapctl get "pi-config.$key")
-    if [ -n "$value" ]; then
-       update_pi_config_value "$key" "$value"
-    fi
+    value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
+    update_pi_config_value "$key" "$value"
 done

--- a/hooks/configure
+++ b/hooks/configure
@@ -81,14 +81,13 @@ update_pi_config_value() {
 
     if [ -z "$v" ]; then
         # empty - unset an option
-        sed -i -e "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
+        sed -i "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
     else
         # non-empty - set an option
-        if grep -q "^[ \t#]*${k}=" "$path"; then
-            sed -i -e "s/^[ \t#]*${k}=.*/$k=$v/" "$path"
-        else
-            echo "$k=$v" >> "$path"
-        fi
+        sed -i \
+        -e "/^[ \t#]*$k=/,\${s/^[ \t#]*$k=.*/$k=$v/;b}" -e "# Replace existing and bail." \
+        -e "\${s/\$/\n$k=$v/}"                          -e "# Append if not found." \
+        "$path"
     fi
 }
 
@@ -109,7 +108,7 @@ PI_CONFIG_KEYS="disable_overscan framebuffer_width framebuffer_height
  overscan_top overscan_bottom overscan_scale display_rotate hdmi_group
  hdmi_mode hdmi_drive avoid_warnings gpu_mem_256 gpu_mem_512 gpu_mem"
 PI_CONFIG="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
-if [ -e "$PI_CONFIG" ]; then
+if [ -f "$PI_CONFIG" ]; then
     for key in $PI_CONFIG_KEYS; do
         value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
         update_pi_config_value "$PI_CONFIG" "$key" "$value"

--- a/hooks/configure
+++ b/hooks/configure
@@ -116,6 +116,10 @@ PI_CONFIG="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
 if [ -f "$PI_CONFIG" ]; then
     for key in $PI_CONFIG_KEYS; do
         value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
+        if ! echo "$value" | grep -q '^[a-zA-Z0-9]*$'; then
+            echo "invalid value: \"$value\" for \"$key\" found" 1>&2
+            exit 1
+        fi
         update_pi_config_value "$PI_CONFIG" "$key" "$value"
     done
 fi

--- a/hooks/configure
+++ b/hooks/configure
@@ -74,6 +74,24 @@ switch_service() {
 	esac
 }
 
+update_pi_config_value() {
+    path="/boot/uboot/config.txt"
+    k="$1"
+    v="$2"
+
+    if [ -z "$v" ]; then
+        # empty - unset an option
+        sed -i -e "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
+    else
+        # non-empty - set an option
+        if grep "$path" "^[ \t#]*${k}="; then
+            sed -i -e "s/^[ \t#]*${k}=.*/$k=$v/" "$path"
+        else
+            echo "$k=$v" >> "$path"
+        fi
+    fi
+}
+
 for service in $SERVICES; do
     value=$(snapctl get service.$service.disable)
     if [ -n "$value" ]; then
@@ -85,3 +103,14 @@ powerkey=$(snapctl get system.power-key-action)
 if [ -n "$powerkey" ]; then
     switch_handle_power_key "$powerkey"
 fi
+
+PI_CONFIG_KEYS="disable_overscan framebuffer_width framebuffer_height
+ framebuffer_depth framebuffer_ignore_alpha overscan_left overscan_right
+ overscan_top overscan_bottom overscan_scale display_rotate hdmi_group
+ hdmi_mode hdmi_drive avoid_warnings gpu_mem_256 gpu_mem_512 gpu_mem"
+for key in $PI_CONFIG_KEYS; do
+    value=$(snapctl get "pi-config.$key")
+    if [ -n "$value" ]; then
+       update_pi_config_value "$key" "$value"
+    fi
+done

--- a/hooks/configure
+++ b/hooks/configure
@@ -84,10 +84,15 @@ update_pi_config_value() {
         sed -i "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
     else
         # non-empty - set an option
-        sed -i \
-        -e "/^[ \t#]*$k=/,\${s/^[ \t#]*$k=.*/$k=$v/;b}" -e "# Replace existing and bail." \
-        -e "\${s/\$/\n$k=$v/}"                          -e "# Append if not found." \
-        "$path"
+        sed -i -f - "$path" <<EOF
+/^[ \t#]*$k=/,\$ {
+ s/^[ \t#]*$k=.*/$k=$v/ # Replace existing (even if commented out)
+ b                      # jump to end (bail)
+}
+# Append line at the end (only reached if option was not found before)
+\$ a\
+$k=$v
+EOF
     fi
 }
 

--- a/hooks/configure
+++ b/hooks/configure
@@ -76,23 +76,29 @@ switch_service() {
 
 update_pi_config_value() {
     path="$1"
-    k="$2"
-    v="$3"
+    key="$2"
+    value="$3"
 
-    if [ -z "$v" ]; then
+    if [ -z "$value" ]; then
         # empty - unset an option
-        sed -i "/^[ \t#]*${k}=/ s/^#*/#/" "$path"
+        sed -i "/^[ \t#]*${key}=/ s/^#*/#/" "$path"
     else
         # non-empty - set an option
-        sed -i -f - "$path" <<EOF
-/^[ \t#]*$k=/,\$ {
- s/^[ \t#]*$k=.*/$k=$v/ # Replace existing (even if commented out)
- b                      # jump to end (bail)
+        export key value
+        awk -v pat="^[ \t#]*$key=.*" --sandbox -f - "$path" >"${path}.tmp" <<'EOF'
+$0 ~ pat {
+     gsub(pat, sprintf("%s=%s",ENVIRON["key"],ENVIRON["value"]))
+     ok=1
 }
-# Append line at the end (only reached if option was not found before)
-\$ a\
-$k=$v
+{
+    print
+}
+END {
+    if (!ok)
+        printf("%s=%s\n",ENVIRON["key"],ENVIRON["value"])
+}
 EOF
+        mv "${path}.tmp" "$path"
     fi
 }
 
@@ -116,10 +122,6 @@ PI_CONFIG="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
 if [ -f "$PI_CONFIG" ]; then
     for key in $PI_CONFIG_KEYS; do
         value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
-        if ! echo "$value" | grep -q '^[a-zA-Z0-9]*$'; then
-            echo "invalid value: \"$value\" for \"$key\" found" 1>&2
-            exit 1
-        fi
         update_pi_config_value "$PI_CONFIG" "$key" "$value"
     done
 fi

--- a/hooks/configure
+++ b/hooks/configure
@@ -75,9 +75,9 @@ switch_service() {
 }
 
 update_pi_config_value() {
-    path="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
-    k="$1"
-    v="$2"
+    path="$1"
+    k="$2"
+    v="$3"
 
     if [ -z "$v" ]; then
         # empty - unset an option
@@ -108,7 +108,10 @@ PI_CONFIG_KEYS="disable_overscan framebuffer_width framebuffer_height
  framebuffer_depth framebuffer_ignore_alpha overscan_left overscan_right
  overscan_top overscan_bottom overscan_scale display_rotate hdmi_group
  hdmi_mode hdmi_drive avoid_warnings gpu_mem_256 gpu_mem_512 gpu_mem"
-for key in $PI_CONFIG_KEYS; do
-    value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
-    update_pi_config_value "$key" "$value"
-done
+PI_CONFIG="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
+if [ -e "$PI_CONFIG" ]; then
+    for key in $PI_CONFIG_KEYS; do
+        value=$(snapctl get "pi-config.$(echo "$key"|tr _ -)")
+        update_pi_config_value "$PI_CONFIG" "$key" "$value"
+    done
+fi

--- a/tests/test_hook_pi_config.py
+++ b/tests/test_hook_pi_config.py
@@ -74,9 +74,3 @@ class TestPiConfigFromConfigureHook(unittest.TestCase):
         expected=mock_config_txt+"framebuffer_depth=32\n"
         subprocess.check_call(["hooks/configure"])
         self.assertEqual(self.read_mock_uboot_config(), expected)
-
-    def test_configure_pi_config_filters_nasty(self):
-        self.mock_uboot_config(mock_config_txt+"\navoid_warnings=1\n")
-        self.mock_snapctl("pi-config.avoid-warnings", "1/;e touch /tmp/foo;")
-        with self.assertRaises(subprocess.CalledProcessError):
-            subprocess.check_output(["hooks/configure"])

--- a/tests/test_hook_pi_config.py
+++ b/tests/test_hook_pi_config.py
@@ -1,0 +1,72 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+mock_config_txt = """
+# For more options and information see
+# http://www.raspberrypi.org/documentation/configuration/config-txt.md
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+#disable_overscan=1
+
+unrelated_options=are-keept
+"""
+
+class TestPiConfigFromConfigureHook(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def mock_uboot_config(self, txt):
+        self.mock_uboot_config = os.path.join(self.tmp, "config.txt")
+        with open(self.mock_uboot_config, "w") as fp:
+            fp.write(txt)
+        os.environ["TEST_UBOOT_CONFIG"]=self.mock_uboot_config
+
+    def mock_snapctl(self, k, v):
+        mock_snapctl=os.path.join(self.tmp, "snapctl")
+        if not self.tmp in os.environ["PATH"]:
+            os.environ["PATH"] = self.tmp+":"+os.environ["PATH"]
+        with open(mock_snapctl, "w") as fp:
+            fp.write("""#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi
+            """ % (k, v))
+        os.chmod(mock_snapctl, 0o755)
+
+    def read_mock_uboot_config(self):
+        with open(self.mock_uboot_config) as fp:
+            content=fp.read()
+        return content
+            
+    def test_configure_pi_config_uncomment_existing(self):
+        self.mock_uboot_config(mock_config_txt)
+        self.mock_snapctl("pi-config.disable-overscan", "1")
+        expected=mock_config_txt.replace("#disable_overscan=1","disable_overscan=1")
+        subprocess.check_call(["hooks/configure"])
+        self.assertEqual(self.read_mock_uboot_config(), expected)
+
+    def test_configure_pi_config_comment_existing(self):
+        self.mock_uboot_config(mock_config_txt+"\navoid_warnings=1\n")
+        self.mock_snapctl("pi-config.avoid-warnings", "")
+        expected=mock_config_txt+"\n#avoid_warnings=1\n"
+        subprocess.check_call(["hooks/configure"])
+        self.assertEqual(self.read_mock_uboot_config(), expected)
+        
+    def test_configure_pi_config_add_new_option(self):
+        self.mock_uboot_config(mock_config_txt)
+        self.mock_snapctl("pi-config.framebuffer-depth", "16")
+        expected=mock_config_txt+"framebuffer_depth=16\n"
+        subprocess.check_call(["hooks/configure"])
+        self.assertEqual(self.read_mock_uboot_config(), expected)
+        # add again, verify its not added twice but updated
+        self.mock_snapctl("pi-config.framebuffer-depth", "32")
+        expected=mock_config_txt+"framebuffer_depth=32\n"
+        subprocess.check_call(["hooks/configure"])
+        self.assertEqual(self.read_mock_uboot_config(), expected)

--- a/tests/test_hook_pi_config.py
+++ b/tests/test_hook_pi_config.py
@@ -74,3 +74,9 @@ class TestPiConfigFromConfigureHook(unittest.TestCase):
         expected=mock_config_txt+"framebuffer_depth=32\n"
         subprocess.check_call(["hooks/configure"])
         self.assertEqual(self.read_mock_uboot_config(), expected)
+
+    def test_configure_pi_config_filters_nasty(self):
+        self.mock_uboot_config(mock_config_txt+"\navoid_warnings=1\n")
+        self.mock_snapctl("pi-config.avoid-warnings", "1/;e touch /tmp/foo;")
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.check_output(["hooks/configure"])

--- a/tests/test_hook_pi_config.py
+++ b/tests/test_hook_pi_config.py
@@ -23,6 +23,9 @@ class TestPiConfigFromConfigureHook(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp)
+        # mock systemctl as well as this is checked from the configure
+        # hook and may not be available everyhwere
+        self.mock_binary("systemctl", "")
 
     def mock_uboot_config(self, txt):
         self.mock_uboot_config = os.path.join(self.tmp, "config.txt")
@@ -30,21 +33,22 @@ class TestPiConfigFromConfigureHook(unittest.TestCase):
             fp.write(txt)
         os.environ["TEST_UBOOT_CONFIG"]=self.mock_uboot_config
 
-    def mock_snapctl(self, k, v):
-        mock_snapctl=os.path.join(self.tmp, "snapctl")
+    def mock_binary(self, basename, script):
+        mocked_binary=os.path.join(self.tmp, basename)
         if not self.tmp in os.environ["PATH"]:
             os.environ["PATH"] = self.tmp+":"+os.environ["PATH"]
-        with open(mock_snapctl, "w") as fp:
-            fp.write("""#!/bin/sh
-if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi
-            """ % (k, v))
-        os.chmod(mock_snapctl, 0o755)
+        with open(mocked_binary, "w") as fp:
+            fp.write("#!/bin/sh\n%s\n" % script)
+        os.chmod(mocked_binary, 0o755)
+
+    def mock_snapctl(self, k, v):
+        self.mock_binary("snapctl", """if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi""" % (k, v))
 
     def read_mock_uboot_config(self):
         with open(self.mock_uboot_config) as fp:
             content=fp.read()
         return content
-            
+
     def test_configure_pi_config_uncomment_existing(self):
         self.mock_uboot_config(mock_config_txt)
         self.mock_snapctl("pi-config.disable-overscan", "1")
@@ -58,7 +62,7 @@ if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi
         expected=mock_config_txt+"\n#avoid_warnings=1\n"
         subprocess.check_call(["hooks/configure"])
         self.assertEqual(self.read_mock_uboot_config(), expected)
-        
+
     def test_configure_pi_config_add_new_option(self):
         self.mock_uboot_config(mock_config_txt)
         self.mock_snapctl("pi-config.framebuffer-depth", "16")


### PR DESCRIPTION
This branch allows configuring the pi{2,3} config.txt file via `snap set core pi-config.*`. It supports the options discussed in LP #1587137 

E.g. `snap set core pi2-config.disable-overscan=1` will set `disable_overscan=1` in `/boot/uboot/config.txt`.

Once that has landed I can also write a spread test in snapd to test this end-to-end instead of the mocking stuff that is currently done in the tests.