### PR TITLE
Build depend on gawk

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,3 +25,4 @@ parts:
     build-packages:
       - livecd-rootfs
       - shellcheck
+      - gawk


### PR DESCRIPTION
This patch adds gawk to build-packages. We are currently seeing build
failures on the launchpad "core" snap recipe. They all complain about
--sanbox being an unknown option. This is a quick shoot in the dark.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>