### PR TITLE
Update core snap cloud-init configuration

### DIFF
--- a/live-build/hooks/09-disable-cloud-init-net-breaking.chroot
+++ b/live-build/hooks/09-disable-cloud-init-net-breaking.chroot
@@ -1,8 +1,0 @@
-#!/bin/sh -x
-
-[ -d /etc/cloud/cloud.cfg.d ] || mkdir -p /etc/cloud/cloud.cfg.d
-
-cat >> /etc/cloud/cloud.cfg.d/99-snappy-disable-network-config.cfg <<EOF
-network:
-  config: disabled
-EOF

--- a/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
+++ b/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+# Ensure cloud-init runs after networkd-wait-online.service since Ubuntu Core uses networkd
+CI_SERVICE=/lib/systemd/system/cloud-init.service
+if ! grep -q 'After=systemd-networkd-wait-online.service' ${CI_SERVICE}; then
+    sed -i -e '/After=networking.service/a After=systemd-networkd-wait-online.service' ${CI_SERVICE};
+fi
+
+# Trigger wait-online service if netplan is updated
+NETWORKD_ONLINE_PATH=/lib/systemd/system/systemd-networkd-wait-online.path
+cat <<EOF >$NETWORKD_ONLINE_PATH
+[Unit]
+Description=Trigger systemd-networkd-wait-online if netplan updates
+
+[Path]
+PathChanged=/run/systemd/generator/netplan.stamp
+EOF
+
+# Ensure we're always using systemd-networkd
+mkdir -p /etc/systemd/system/network-online.target.wants
+ln -sf /lib/systemd/system/systemd-networkd.service /etc/systemd/system/network-online.target.wants/systemd-networkd.service ||:
+
+exit 0

--- a/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
+++ b/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
@@ -21,5 +21,3 @@ EOF
 # Ensure we're always using systemd-networkd
 mkdir -p /etc/systemd/system/network-online.target.wants
 ln -sf /lib/systemd/system/systemd-networkd.service /etc/systemd/system/network-online.target.wants/systemd-networkd.service ||:
-
-exit 0


### PR DESCRIPTION
- cloud-init handles working with UC16's built-in netplan configuration without disabling cloud-init's network configuration
- Ensure that cloud-init service works with networkd;  cloud-init in Xenial (which doesn't use
networkd by default) can't change packaging so adjust core configuration.
