### PR TITLE
the core snap only needs core-support  (not network-bind)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,8 +9,6 @@ grade: stable
 plugs:
   core-support-plug:
     interface: core-support
-  network-bind-plug:
-    interface: network-bind
 
 hooks:
   configure:


### PR DESCRIPTION
This can only land if https://github.com/snapcore/snapd/pull/3166 lands.