### PR TITLE
move xdg-open to proper paths

### DIFF
--- a/live-build/hooks/500-create-xdg-wrapper.binary
+++ b/live-build/hooks/500-create-xdg-wrapper.binary
@@ -6,26 +6,26 @@ echo "I: Creating xdg helper"
 
 PREFIX=binary/boot/filesystem.dir
 
-mkdir -p $PREFIX/usr/local/bin
-cat >$PREFIX/usr/local/bin/xdg-open <<EOF
+mkdir -p $PREFIX/usr/bin
+cat >$PREFIX/usr/bin/xdg-open <<EOF
 #!/bin/sh
 dbus-send --print-reply --session --dest=com.canonical.SafeLauncher / com.canonical.SafeLauncher.OpenURL string:"\$1"
 EOF
-chmod 755 $PREFIX/usr/local/bin/xdg-open
+chmod 755 $PREFIX/usr/bin/xdg-open
 
 # corresponding .desktop entry, needed for mimetype registration
-mkdir -p $PREFIX/usr/local/share/applications
-cat >$PREFIX/usr/local/share/applications/xdg-open.desktop <<EOF
+mkdir -p $PREFIX/usr/share/applications
+cat >$PREFIX/usr/share/applications/xdg-open.desktop <<EOF
 [Desktop Entry]
 Version=1.0
 Name=Url Handler Script
-Exec=/usr/local/bin/xdg-open %u
+Exec=/usr/bin/xdg-open %u
 MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
 Type=Application
 EOF
 
 # define xdg-open as the default handler for common types
-cat >$PREFIX/usr/local/share/applications/mimeapps.list <<EOF
+cat >$PREFIX/usr/share/applications/mimeapps.list <<EOF
 [Added Associations]
 x-scheme-handler/http=xdg-open.desktop
 x-scheme-handler/https=xdg-open.desktop


### PR DESCRIPTION
do not put xdg-open into /usr/local. we kept it there initially with the possibility of a personal-core snap in mind where the real xdg-open would be included but this is unlikely to happen. instead of having to mangle the PATH variable in snap wrappers the binary can now be found right away in $PATH without extra adjustment.