### PR TITLE
install keyring (LP: #1670475), update pkglists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - LC_ALL=C.UTF-8
     - LANG=C.UTF-8
 install:
-  - sudo apt install shellcheck
   - mkdir -p $CHROOT/build
   - wget -q -O - $URL | zcat - | sudo tar x -C $CHROOT
   - sudo cp /etc/resolv.conf $CHROOT/etc/
@@ -22,5 +21,4 @@ install:
   - sudo chroot $CHROOT apt install -y livecd-rootfs snapcraft
   - sudo cp -a Makefile snapcraft.yaml hooks live-build $CHROOT/build
 script:
-  - make check
   - sudo chroot $CHROOT sh -c 'mount -t proc proc /proc; mount -t sysfs sys /sys; cd build; snapcraft'

--- a/live-build/hooks/300-create-classic-diff.binary
+++ b/live-build/hooks/300-create-classic-diff.binary
@@ -12,7 +12,7 @@ PREFIX=binary/boot/filesystem.dir
 (cd $PREFIX
  mkdir -p var/lib/classic
  apt-get clean
- apt-get -y install --reinstall -d apt locales base-files libapt-inst2.0 libapt-pkg5.0
+ apt-get -y install --reinstall -d apt locales base-files libapt-inst2.0 libapt-pkg5.0 ubuntu-keyring
  cp /var/cache/apt/archives/*.deb var/cache/apt/archives/
 
  tar czvf var/lib/classic/classic-diff.tgz \
@@ -33,6 +33,7 @@ dpkg -i /var/cache/apt/archives/*.deb
 dpkg -i --force-confask --force-confnew /var/cache/apt/archives/base-files*.deb
 
 apt-get clean
+apt-get update
 EOF
 
 chmod +x var/lib/classic/enable.sh


### PR DESCRIPTION
- make sure we have a valid archive keyring in place to prevent gpg issues (part of LP: #1670475)
- force-run apt-get update when we create the classic chroot
- tests: drop wrong shellcheck version, it runs inside the chroot during build with the right version instead.