### PR TITLE
Add another pi-config option

### DIFF
--- a/hooks/configure
+++ b/hooks/configure
@@ -123,7 +123,7 @@ PI_CONFIG_KEYS="disable_overscan framebuffer_width framebuffer_height
  framebuffer_depth framebuffer_ignore_alpha overscan_left overscan_right
  overscan_top overscan_bottom overscan_scale display_rotate hdmi_group
  hdmi_mode hdmi_drive avoid_warnings gpu_mem_256 gpu_mem_512 gpu_mem
- sdtv_aspect config_hdmi_boost hdmi_force_hotplug"
+ sdtv_aspect config_hdmi_boost hdmi_force_hotplug program_usb_boot_mode"
 PI_CONFIG="${TEST_UBOOT_CONFIG:-/boot/uboot/config.txt}"
 if [ -f "$PI_CONFIG" ]; then
     for key in $PI_CONFIG_KEYS; do


### PR DESCRIPTION
This commit allows to use boot from usb functionality. It was implemented in the core at the end of previous year if I remember correctly but to use it this option is required according to this - https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md