### PR TITLE
add version-script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@ DPKG_ARCH := $(shell dpkg --print-architecture)
 RELEASE := $(shell lsb_release -c -s)
 ENV := PROJECT=ubuntu-core SUBPROJECT=system-image EXTRA_PPAS='snappy-dev/image snappy-dev/edge' IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
 
-# workaround for LP: #1588336, needs to be bumped along
-# with the snapcraft.yaml version for now
-VERSION := 16-2
-
 #ifneq ($(shell grep $(RELEASE)-proposed /etc/apt/sources.list),)
 #ENV += PROPOSED=1
 #endif
@@ -34,7 +30,7 @@ install:
 	mv binary/boot/filesystem.dir/* $(DESTDIR)/
 	# only copy the manifest file if we are in a launchpad buildd
 	if [ -e /build/core ]; then \
-	  mv livecd.ubuntu-core.manifest /build/core/core_$(VERSION)_$(DPKG_ARCH).manifest; \
+	  mv livecd.ubuntu-core.manifest /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=)_$(DPKG_ARCH).manifest; \
 	  ls -l /build/core; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ https://bugs.launchpad.net/snapd/+filebug
 
 ## Building
 
-To build the core snap locally please use `sudo snapcraft` in a 16.04
-chroot or container.
+To build the core snap locally you need a chroot or container with
+Ubuntu 16.04. Then run:
+
+    $ sudo apt-add-repository ppa:snappy-dev/image
+    $ sudo snapcraft
 
 An easy way to customize the content of the built snap is including additional
 PPAs with custom packages in the `EXTRA_PPAS` variable inside the Makefile's

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ https://bugs.launchpad.net/snapd/+filebug
 
 ## Building
 
-To build the core snap locally please use `sudo snapcraft`.
+To build the core snap locally please use `sudo snapcraft` in a 16.04
+chroot or container.
 
 An easy way to customize the content of the built snap is including additional
 PPAs with custom packages in the `EXTRA_PPAS` variable inside the Makefile's

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,7 @@
 name: core
 version: 16-2
+version-script: |
+    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=)"
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
This adds version information to the core snap. 

Also updates the readme as the snapcraft will fail when running on a non 16.04 system.