### PR TITLE
make links to /etc/writable absolute

### DIFF
--- a/live-build/hooks/08-etc-writable.chroot
+++ b/live-build/hooks/08-etc-writable.chroot
@@ -11,7 +11,7 @@ for f in timezone localtime hostname; do
         mv /etc/$f /etc/writable/$f
     fi
     echo "I: Linking /etc/$f to /etc/writable/"
-    ln -s writable/$f /etc/$f
+    ln -s /etc/writable/$f /etc/$f
 done
 
 # create systemd override dirs


### PR DESCRIPTION
https://bugs.launchpad.net/snappy/+bug/1650688 might potentially be fixed by this (our systemd already ships http://paste.ubuntu.com/24559979/)