### PR TITLE
fix version number length

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: core
 version: 16-2
 version-script: |
-    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=|cut -b1-32)"
+    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=|cut -b1-29)"
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
The version number has a `16-` prefix so the amount of version number information in the suffix is only 29 chars, not 32 :)