### PR TITLE
remove generated logs, cleaner lsb-release removal

### DIFF
--- a/live-build/hooks/300-create-classic-diff.binary
+++ b/live-build/hooks/300-create-classic-diff.binary
@@ -12,7 +12,7 @@ PREFIX=binary/boot/filesystem.dir
 (cd $PREFIX
  mkdir -p var/lib/classic
  apt-get clean
- apt-get -y install --reinstall -d apt locales base-files libapt-inst2.0 libapt-pkg5.0 ubuntu-keyring
+ apt-get -y install --reinstall -d apt locales base-files libapt-inst2.0 libapt-pkg5.0 ubuntu-keyring lsb-release
  cp /var/cache/apt/archives/*.deb var/cache/apt/archives/
 
  tar czvf var/lib/classic/classic-diff.tgz \

--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -16,7 +16,7 @@ PREFIX=binary/boot/filesystem.dir
 
 # dpkg-deb and dpkg purposefully left behind
 (cd $PREFIX
-    chroot . dpkg --purge --force-depends apt libapt-inst2.0 libapt-pkg5.0
+    chroot . dpkg --purge --force-depends apt libapt-inst2.0 libapt-pkg5.0 lsb-release
     rm -r \
         var/lib/dpkg \
         var/log/apt
@@ -31,6 +31,9 @@ PREFIX=binary/boot/filesystem.dir
     # remove generated locales for packages we do not use
     rm -f usr/share/locale/*/LC_MESSAGES/dpkg*
     rm -f usr/share/locale/*/LC_MESSAGES/libapt*
-    # also remove lsb_release (LP: #1619420)
-    rm -f usr/bin/lsb_release
+    # remove generated logs
+    rm -f var/log/bootstrap.log \
+          var/log/alternatives.log \
+          var/log/dpkg.log
+    
 )

--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -35,5 +35,8 @@ PREFIX=binary/boot/filesystem.dir
     rm -f var/log/bootstrap.log \
           var/log/alternatives.log \
           var/log/dpkg.log
+    # also remove obsolete cron jobs
+    rm -f /etc/cron.daily/dpkg \
+          /etc/cron.daily/passwd
     
 )


### PR DESCRIPTION
- remove all generated dpkg logfiles created during build
- remove lsb-release binary more cleanly (and add it to the classic diff instead)
- drop unneeded cron jobs (dpkg and passwd backups)