### PR TITLE
allow rsyslog disabling

### DIFF
--- a/hooks/configure
+++ b/hooks/configure
@@ -108,7 +108,7 @@ EOF
 }
 
 for service in $SERVICES; do
-    value=$(snapctl get service.$service.disable)
+    value=$(snapctl get service."$service".disable)
     if [ -n "$value" ]; then
         switch_service "$value" "$service"
     fi

--- a/hooks/configure
+++ b/hooks/configure
@@ -21,7 +21,7 @@ if ! systemctl --version >/dev/null 2>&1; then
 fi
 
 # list of services we can disable and enable
-SERVICES="ssh"
+SERVICES="ssh rsyslog"
 
 switch_handle_power_key() {
     dir="/etc/systemd/logind.conf.d"


### PR DESCRIPTION
following the discussion at https://forum.snapcraft.io/t/change-in-logging-behaviour-on-ubuntu-core/591
and https://bugs.launchpad.net/snappy/+bug/1587453 allow to use the service.rsyslog.disable=true|false setting to select if syslog should be running.