### PR TITLE
cut the trailing ~ubuntu16.04 from the version that the PPA auto-generates

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: core
 version: 16-2
 version-script: |
-    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=|cut -b1-29)"
+    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=| cut -f1 -d~ | cut -b1-29)"
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
Tiny branch to make the version number of the core snap equal to what mkversion.sh would do.

This is needed because the PPA version number will automatically add ` ~ubuntu16.04` (and similar) for each distro. 