### PR TITLE
add support for `snap set core proxy.{http,https,ftp,all}`

### DIFF
--- a/hooks/configure
+++ b/hooks/configure
@@ -74,22 +74,29 @@ switch_service() {
 	esac
 }
 
-update_pi_config_value() {
-    path="$1"
-    key="$2"
-    value="$3"
+# helper that checks if the given tmp_path can be written
+is_writable() {
+    tmp_path="$1"
+    printf "" 2>/dev/null >> "$tmp_path"
+}
 
-    if [ -z "$value" ]; then
-        # empty - unset an option
-        if grep -q "^[ \t]*${key}=" "$path"; then
-            sed "/^[ \t#]*${key}=/ s/^#*/#/" "$path" > "${path}.tmp"
-            mv "${path}.tmp" "$path"
-        fi
-    else
-        if ! grep -q "^[ \t]*${key}=${value}$" "$path"; then
-            # non-empty - set an option
-            export key value
-            gawk --sandbox -v pat="^[ \t#]*$key=.*" -f - "$path" >"${path}.tmp" <<'EOF'
+# replace_or_append is a helper that will replace an existing option
+# in a key=value file. If the option is missing it will append the
+# option.
+key_value_replace_or_append() {
+    key="$1"
+    value="$2"
+    path="$3"
+    tmp_path="${path}.tmp"
+
+    # not writable, most likely due to a read-only directory, e.g. when
+    # dealing with /etc/envirionment on core
+    if ! is_writable "$tmp_path"; then
+        tmp_path="$(mktemp)"
+    fi
+
+    export key value
+    gawk --sandbox -v pat="^[ \t#]*$key=.*" -f - "$path" >"${tmp_path}" <<'EOF'
 $0 ~ pat {
      gsub(pat, sprintf("%s=%s",ENVIRON["key"],ENVIRON["value"]))
      ok=1
@@ -102,7 +109,50 @@ END {
         printf("%s=%s\n",ENVIRON["key"],ENVIRON["value"])
 }
 EOF
-            mv "${path}.tmp" "$path"
+    mv "${tmp_path}" "$path"
+}
+
+update_pi_config_value() {
+    path="$1"
+    key="$2"
+    value="$3"
+
+    if [ -z "$value" ]; then
+        # empty - unset an option
+        if grep -q "^[ \t]*${key}=" "$path"; then
+            tmp_path="${path}.tmp"
+
+            sed "/^[ \t#]*${key}=/ s/^#*/#/" "$path" > "${tmp_path}"
+            mv "${tmp_path}" "$path"
+        fi
+    else
+        if ! grep -q "^[ \t]*${key}=${value}$" "$path"; then
+            # non-empty - set an option
+            key_value_replace_or_append "$key" "$value" "$path"
+        fi
+    fi
+}
+
+switch_proxy() {
+    path="$1"
+    proxy="${2}_proxy"
+    value="$3"
+
+    if [ -z "$value" ]; then
+        if grep -q "^${proxy}=.*" "$path";then
+            tmp_path="${path}.tmp"
+            # not writable, most likely due to a read-only directory, e.g. when
+            # dealing with /etc/envirionment on core
+            if ! is_writable "$tmp_path"; then
+                tmp_path="$(mktemp)"
+            fi
+
+            sed  "/^${proxy}=.*/d" "$path" > "${tmp_path}"
+            mv "${tmp_path}" "${path}"
+        fi
+    else
+        if ! grep -q "^${proxy}=${value}" "$path";then
+            key_value_replace_or_append "$proxy" "$value" "$path"
         fi
     fi
 }
@@ -131,3 +181,9 @@ if [ -f "$PI_CONFIG" ]; then
         update_pi_config_value "$PI_CONFIG" "$key" "$value"
     done
 fi
+
+ETC_ENVIRONMENT="${TEST_ETC_ENVIRONMENT:-/etc/environment}"
+for proxy in http https ftp all; do
+    value=$(snapctl get "proxy.${proxy}")
+    switch_proxy "$ETC_ENVIRONMENT" "$proxy" "$value"
+done

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,19 @@
+import os
+import unittest
+
+
+class ConfigureTestCase(unittest.TestCase):
+
+    def mock_binary(self, basename, script):
+        mocked_binary=os.path.join(self.tmp, basename)
+        if not self.tmp in os.environ["PATH"]:
+            os.environ["PATH"] = self.tmp+":"+os.environ["PATH"]
+        with open(mocked_binary, "w") as fp:
+            fp.write("#!/bin/sh\n%s\n" % script)
+        os.chmod(mocked_binary, 0o755)
+
+    def mock_snapctl(self, k, v):
+        self.mock_binary("snapctl", """if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi""" % (k, v))
+
+    
+

--- a/tests/test_hook_pi_config.py
+++ b/tests/test_hook_pi_config.py
@@ -1,8 +1,23 @@
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import shutil
 import subprocess
 import tempfile
-import unittest
+
+from .test_configure import ConfigureTestCase
 
 mock_config_txt = """
 # For more options and information see
@@ -19,7 +34,7 @@ mock_config_txt = """
 unrelated_options=are-keept
 """
 
-class TestPiConfigFromConfigureHook(unittest.TestCase):
+class TestPiConfigFromConfigureHook(ConfigureTestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp)
@@ -32,17 +47,6 @@ class TestPiConfigFromConfigureHook(unittest.TestCase):
         with open(self.mock_uboot_config, "w") as fp:
             fp.write(txt)
         os.environ["TEST_UBOOT_CONFIG"]=self.mock_uboot_config
-
-    def mock_binary(self, basename, script):
-        mocked_binary=os.path.join(self.tmp, basename)
-        if not self.tmp in os.environ["PATH"]:
-            os.environ["PATH"] = self.tmp+":"+os.environ["PATH"]
-        with open(mocked_binary, "w") as fp:
-            fp.write("#!/bin/sh\n%s\n" % script)
-        os.chmod(mocked_binary, 0o755)
-
-    def mock_snapctl(self, k, v):
-        self.mock_binary("snapctl", """if [ "$1" = "get" ] && [ "$2" = "%s" ]; then echo "%s"; fi""" % (k, v))
 
     def read_mock_uboot_config(self):
         with open(self.mock_uboot_config) as fp:

--- a/tests/test_hook_proxy.py
+++ b/tests/test_hook_proxy.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+from .test_configure import ConfigureTestCase
+
+mock_etc_environment = """PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+"""
+
+class TestConfigureHookProxy(ConfigureTestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def mock_etc_environment(self, txt):
+        self.mock_etc_environment_path = os.path.join(self.tmp, "environment")
+        with open(self.mock_etc_environment_path, "w") as fp:
+            fp.write(txt)
+        os.environ["TEST_ETC_ENVIRONMENT"]=self.mock_etc_environment_path
+
+    def read_mock_etc_environment(self):
+        with open(self.mock_etc_environment_path) as fp:
+            content=fp.read()
+        return content
+
+    def test_configure_proxy_adds_new(self):
+        self.mock_etc_environment(mock_etc_environment)
+        self.mock_snapctl("proxy.http", "http://bar.com")
+        
+        subprocess.check_call(["hooks/configure"])
+
+        expected=mock_etc_environment+"http_proxy=http://bar.com\n"
+        self.assertEqual(self.read_mock_etc_environment(), expected)
+
+    def test_configure_proxy_replace_existing(self):
+        self.mock_etc_environment(mock_etc_environment+"http_proxy=http://foo.com")
+        self.mock_snapctl("proxy.http", "http://bar.com")
+        
+        subprocess.check_call(["hooks/configure"])
+
+        expected=mock_etc_environment+"http_proxy=http://bar.com\n"
+        self.assertEqual(self.read_mock_etc_environment(), expected)
+
+    def test_configure_proxy_removes_existing(self):
+        self.mock_etc_environment(mock_etc_environment+"http_proxy=http://foo.com")
+        self.mock_snapctl("proxy.http", "")
+        
+        subprocess.check_call(["hooks/configure"])
+
+        expected=mock_etc_environment
+        self.assertEqual(self.read_mock_etc_environment(), expected)
+
+    def test_configure_proxy_replaces_with_ro_directory(self):
+        self.mock_etc_environment(mock_etc_environment+"http_proxy=some")
+        self.mock_snapctl("proxy.http", "http://bar.com")
+        # simulate that bits of the dir are not writable
+        with open(self.mock_etc_environment_path+".tmp", "w"):
+            pass
+        os.chmod(self.mock_etc_environment_path+".tmp", 0o555)
+        
+        subprocess.check_call(["hooks/configure"])
+
+        expected=mock_etc_environment+"http_proxy=http://bar.com\n"
+        self.assertEqual(self.read_mock_etc_environment(), expected)
+
+    def test_configure_proxy_removes_with_ro_directory(self):
+        self.mock_etc_environment(mock_etc_environment+"http_proxy=some")
+        self.mock_snapctl("proxy.http", "")
+        # simulate that bits of the dir are not writable
+        with open(self.mock_etc_environment_path+".tmp", "w"):
+            pass
+        os.chmod(self.mock_etc_environment_path+".tmp", 0o555)
+        
+        subprocess.check_call(["hooks/configure"])
+
+        expected=mock_etc_environment
+        self.assertEqual(self.read_mock_etc_environment(), expected)
+
+    def test_configure_proxy_no_change_unset(self):
+        self.mock_etc_environment(mock_etc_environment)
+        st1 = os.stat(self.mock_etc_environment_path)
+        self.mock_snapctl("proxy.http", "")
+        subprocess.check_call(["hooks/configure"])
+        st2 = os.stat(self.mock_etc_environment_path)
+        self.assertEqual(st1.st_mtime_ns, st2.st_mtime_ns)
+
+    def test_configure_proxy_no_change_set(self):
+        self.mock_etc_environment(mock_etc_environment+"http_proxy=http://foo.com")
+        st1 = os.stat(self.mock_etc_environment_path)
+        self.mock_snapctl("proxy.http", "http://foo.com")
+        subprocess.check_call(["hooks/configure"])
+        st2 = os.stat(self.mock_etc_environment_path)
+        self.assertEqual(st1.st_mtime_ns, st2.st_mtime_ns)
+
+    def test_configure_proxy_adds_new_all_supported_proxies(self):
+        for proto in ["http", "https", "ftp", "all"]:
+            self.mock_etc_environment(mock_etc_environment)
+            self.mock_snapctl("proxy.{}".format(proto), "{}://bar.com".format(proto))
+            subprocess.check_call(["hooks/configure"])
+
+            expected=mock_etc_environment+"{}_proxy={}://bar.com\n".format(proto, proto)
+            self.assertEqual(self.read_mock_etc_environment(), expected)


### PR DESCRIPTION
This branch adds support for  `snap set core proxy.{http,https,ftp,all}` plus tests and refactor to DRY in the configure hook.