### PR TITLE
fix snapd.core-fixup.service symlink on core devices

### DIFF
--- a/live-build/hooks/26-fixup-core.chroot
+++ b/live-build/hooks/26-fixup-core.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+echo "Setting snapd.core-fixup.service symlink"
+ln -s /lib/systemd/system/snapd.core-fixup.service /lib/systemd/system/multi-user.target.wants/snapd.core-fixup.service


### PR DESCRIPTION
The deb packages only installs /etc/.../multi-user.target.wants but for core we need it in /lib