### PR TITLE
Ensure the snap-repair.timer is available on refresh as well

### DIFF
--- a/live-build/hooks/26-fixup-core.chroot
+++ b/live-build/hooks/26-fixup-core.chroot
@@ -4,3 +4,6 @@ set -e
 
 echo "Setting snapd.core-fixup.service symlink"
 ln -s /lib/systemd/system/snapd.core-fixup.service /lib/systemd/system/multi-user.target.wants/snapd.core-fixup.service
+
+echo "Setting snap-repair.timer symlink"
+ln -s /lib/systemd/system/snap-repair.timer /lib/systemd/system/timers.target.wants/snap-repair.timer


### PR DESCRIPTION
The snapd deb will install the snap-repair.timer symlink into
 /etc/systemd/system/timers.target.wants/snap-repair.timer

However on a refresh on a core device this path will not
show up because of the way that our writable path system
works. It will not merge existing directories. Fortunately
we can simply install the unit in /lib.