### PR TITLE
Create mount points for use in exposing host system fontconfig

### DIFF
--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -9,3 +9,9 @@ mkdir -p /lib/firmware
 mkdir -p /writable
 mkdir -p /var/lib/systemd/rfkill
 touch /etc/machine-id
+
+echo "creating fontconfig mount points" >&2
+mkdir -p /etc/fonts
+mkdir -p /usr/share/fonts
+mkdir -p /usr/local/share/fonts
+mkdir -p /var/cache/fontconfig

--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -11,7 +11,6 @@ mkdir -p /var/lib/systemd/rfkill
 touch /etc/machine-id
 
 echo "creating fontconfig mount points" >&2
-mkdir -p /etc/fonts
 mkdir -p /usr/share/fonts
 mkdir -p /usr/local/share/fonts
 mkdir -p /var/cache/fontconfig


### PR DESCRIPTION
This PR is based on discussions from the following forum thread:

https://forum.snapcraft.io/t/desktop-allow-access-to-host-system-fonts/1796

We want to mount the host system's fonts, fontconfig configuration files, and global fontconfig cache at the same file system locations within the sandbox.  Zygmunt suggested that creating the empty directories to use as mount points in the core snap would be a better option than waiting for his layouts work to complete (and presumably for follow on work allowing interfaces to affect the layout of a snap).