### PR TITLE
Remove ~ubuntu* instead of cutting after the first "~"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: core
 version: 16-2
 version-script: |
     # remember to keep version script in sync with "Makefile"
-    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=| cut -f1 -d~ | cut -b1-29)"
+    echo "16-$(cat prime/usr/lib/snapd/info |cut -f2 -d=| sed s/~ubuntu.*// | cut -b1-29)"
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
This fixes the problem that a version like "2.28\~rc1" shows up
as 2.28 in `snap info core'. The PPA version strings like:
2.27.5+git358.02243d2~ubuntu17.04.1 will still be displayed
correctly as 2.27.5+git358.02243d2.