### PR TITLE
fix typo in 500-create-xdg-wrapper.binary

### DIFF
--- a/live-build/hooks/500-create-xdg-wrapper.binary
+++ b/live-build/hooks/500-create-xdg-wrapper.binary
@@ -11,7 +11,7 @@ cat >$PREFIX/usr/bin/xdg-open <<EOF
 #!/bin/sh
 if ! dbus-send --print-reply --session --dest=io.snapcraft.Launcher / io.snapcraft.Launcher.OpenURL string:"\$1"; then
    # compat
-   dbus-send --print-reply --session --dest=com.canonial.SafeLauncher / com.canonical.SafeLauncher.OpenURL string:"\$1"
+   dbus-send --print-reply --session --dest=com.canonical.SafeLauncher / com.canonical.SafeLauncher.OpenURL string:"\$1"
 fi
 EOF
 chmod 755 $PREFIX/usr/bin/xdg-open


### PR DESCRIPTION
There was a copy/paste error when creating the previous xdg-wrapper helper. This PR fixes this.