### PR TITLE
Fix handling of secondary addresses

### DIFF
--- a/live-build/hooks/27-systemd-defaults.chroot
+++ b/live-build/hooks/27-systemd-defaults.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+# Fix default handling of secondary interfaces, see LP: #1721223 for
+# details.
+echo "Setting up sysctl.d defaults to fix LP: #1721223"
+cat >> /etc/sysctl.conf <<EOF
+
+# Promote secondary addresses when the primary address is removed
+net.ipv4.conf.default.promote_secondaries = 1
+net.ipv4.conf.all.promote_secondaries = 1
+EOF


### PR DESCRIPTION
The default behaviour of the kernel is to take down the secondary
addresses when a primary address goes away. However this is not
what we want with networkd (and the systemd upstream changes this
in its sysctl.d/50-default.conf in the upstream git tree). The
way networkd works is to add a new DHCP IP as a secondary address
and when the previous address goes away the secondary address
needs to be promoted, not removed. This patch fixes this behaviour.