### PR TITLE
25-create-generic-initrd.chroot: use symlink instead of copy

### DIFF
--- a/live-build/hooks/25-create-generic-initrd.chroot
+++ b/live-build/hooks/25-create-generic-initrd.chroot
@@ -22,5 +22,5 @@ sha1sum /boot/initrd.img-core >/var/lib/initramfs-tools/core
 mkdir -p /usr/lib/ubuntu-core-generic-initrd
 for f in /boot/initrd.img*; do
     # use relative path as this is inside the core snap which may be relocated
-    ln -s ../../../boot/$(basename $f) /usr/lib/ubuntu-core-generic-initrd/
+    ln -s ../../../boot/"$(basename "$f")" /usr/lib/ubuntu-core-generic-initrd/
 done

--- a/live-build/hooks/25-create-generic-initrd.chroot
+++ b/live-build/hooks/25-create-generic-initrd.chroot
@@ -20,4 +20,7 @@ sha1sum /boot/initrd.img-core >/var/lib/initramfs-tools/core
 
 # for snapcraft backwards compatibility
 mkdir -p /usr/lib/ubuntu-core-generic-initrd
-cp -a /boot/initrd.img-core* /usr/lib/ubuntu-core-generic-initrd/
+for f in /boot/initrd.img*; do
+    # use relative path as this is inside the core snap which may be relocated
+    ln -s ../../../boot/$(basename $f) /usr/lib/ubuntu-core-generic-initrd/
+done


### PR DESCRIPTION
There was  a discussion about the core snap files recently. One of the observations was that we currently ship two initrd.img images. This is not a problem as such as squashfs compresses the two identical files away. However it is a problem when a delta is generated via the `bsdiff` mechanism. This method will look into the squashfs data itself and because initrd is compressed it apparently has trouble generating a optional delta.