### PR TITLE
xdg-settings: make the reply timeout for xdg-settings set 5min

### DIFF
--- a/live-build/hooks/500-create-xdg.binary
+++ b/live-build/hooks/500-create-xdg.binary
@@ -45,6 +45,8 @@ EOF
 cat >$PREFIX/usr/bin/xdg-settings <<'EOF'
 #!/bin/sh
 #
+set -e
+
 # we need to add a "cut -b4-" everyhwere because
 # `dbus-send --print-reply=literal` indents the output by 3 spaces
 # (hardcoded in dbus-print-message.c:print_iter)

--- a/live-build/hooks/500-create-xdg.binary
+++ b/live-build/hooks/500-create-xdg.binary
@@ -54,7 +54,8 @@ if [ "$1" = "get" ]; then
 elif [ "$1" = "check" ]; then
    dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Check string:"$2" string:"$3" | cut -b4-
 elif [ "$1" = "set" ]; then
-   dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Set string:"$2" string:"$3" | cut -b4-
+   # timeout of 300s to ensure the user has enough time to make a decision
+   dbus-send --reply-timeout=300000 --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Set string:"$2" string:"$3" | cut -b4-
 else
    echo "unknown action $2"
 fi


### PR DESCRIPTION
The xdg-settings set will pop up a dialog that needs to be confirmed
by the user. This confirmation may take some time so the default
timeout of ~25sec is too low. We will also make the dialag that
`snap userd` pops up timeout after 5 min.