### PR TITLE
500-create-xdg.binary: use "set -o pipefail" 

### DIFF
--- a/live-build/hooks/500-create-xdg.binary
+++ b/live-build/hooks/500-create-xdg.binary
@@ -43,9 +43,10 @@ x-scheme-handler/help=xdg-open.desktop
 EOF
 
 cat >$PREFIX/usr/bin/xdg-settings <<'EOF'
-#!/bin/sh
+#!/bin/bash
 #
 set -e
+set -o pipefail
 
 # we need to add a "cut -b4-" everyhwere because
 # `dbus-send --print-reply=literal` indents the output by 3 spaces


### PR DESCRIPTION
To ensure xdg-settings  dbus call error fail correctly and to avoid that the `| cut` clobbers the error.

The fixes the test failure in https://github.com/snapcore/snapd/pull/4073