### PR TITLE
hooks: fix shellcheck complains

### DIFF
--- a/live-build/hooks/10-remove-documentation.binary
+++ b/live-build/hooks/10-remove-documentation.binary
@@ -1,8 +1,8 @@
 #!/bin/sh -x
 
 echo "I: Remove unneeded files from /usr/share/doc "
-find -print0 binary/boot/filesystem.dir/usr/share/doc -depth -type f ! -name copyright|xargs -0 rm -f || true
-find -print0 binary/boot/filesystem.dir/usr/share/doc -empty|xargs -0 rmdir || true
+find binary/boot/filesystem.dir/usr/share/doc -print0 -depth -type f ! -name copyright|xargs -0 rm -f || true
+find binary/boot/filesystem.dir/usr/share/doc -print0 -empty|xargs -0 rmdir || true
 find binary/boot/filesystem.dir/usr/share/doc -type f -exec gzip -9 {} \;
 
 echo "I: Remove man/info pages"
@@ -15,7 +15,7 @@ rm -rf binary/boot/filesystem.dir/usr/share/man \
     
 
 echo "I: Removing /var/lib/apt/lists/*"
-find -print0 binary/boot/filesystem.dir/var/lib/apt/lists/ -type f | xargs -0 rm -f
+find binary/boot/filesystem.dir/var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
 
 echo "I: Removing /var/cache/apt/*.bin"
 rm -f binary/boot/filesystem.dir/var/cache/apt/*.bin

--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -14,7 +14,7 @@ if [ "$(dpkg --print-architecture)" = "amd64" ]; then
     apt-get -y install libc6:i386
 
     echo "I: Removing /var/lib/apt/lists/*"
-    find -print0 /var/lib/apt/lists/ -type f | xargs -0 rm -f
+    find /var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
 
     echo "I: Removing /var/cache/apt/*.bin"
     rm -f /var/cache/apt/*.bin


### PR DESCRIPTION
Shellcheck in artful complains about the ordering for `find`, i.e. the first arg must the the path. This PR fixes this.