### PR TITLE
hooks: use symlink to run `snap advise-command`

### DIFF
--- a/live-build/hooks/28-command-not-found.chroot
+++ b/live-build/hooks/28-command-not-found.chroot
@@ -2,5 +2,11 @@
 
 set -e
 
+SNAPD_VER=$(cut -f2 -d= /usr/lib/snapd/info)
+if dpkg --compare-version "$SNAPD_VER" lt 2.30+git; then
+    echo "building for a version that does not support `snap adsive-command` yet"
+    exit 0
+fi
+
 # integrate the new `snap advice-command` into command_not_found_handle
 ln -s /usr/bin/snap /usr/bin/command-not-found

--- a/live-build/hooks/28-command-not-found.chroot
+++ b/live-build/hooks/28-command-not-found.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+# integrate the new `snap advice-command` into command_not_found_handle
+ln -s /usr/bin/snap /usr/bin/command-not-found


### PR DESCRIPTION
Once https://github.com/snapcore/snapd/pull/4450 lands we can just use a symlink for `command-not-found`.