### PR TITLE
live-build: make /lib64/ld-linux-x86-64.so.2 a relative link

### DIFF
--- a/live-build/hooks/29-fix-ld-so-symlink.chroot
+++ b/live-build/hooks/29-fix-ld-so-symlink.chroot
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+echo "Making the /lib64/ld-linux-x86-64.so.2 symlink relative"
+if [ "$(readlink -f /lib64/ld-linux-x86-64.so.2)" = "/lib/x86_64-linux-gnu/ld-2.23.so" ]; then
+    # we must do it in one go (-f) because everything dynamically linked
+    # on the system is  broken when /lib/x86_64-linux-gnu/ld-2.23.so is
+    # missing
+    ln -f -s ../lib/x86_64-linux-gnu/ld-2.23.so /lib64/ld-linux-x86-64.so.2
+fi


### PR DESCRIPTION
This should help with bug:
https://bugs.launchpad.net/snapd/+bug/1684063

Right now classic snaps will fail on distros (like zesty) that
have a different version of the dynamic linker than xenial.