### PR TITLE
live-build: fix order of -print0 in find

### DIFF
--- a/live-build/hooks/10-remove-documentation.binary
+++ b/live-build/hooks/10-remove-documentation.binary
@@ -1,8 +1,8 @@
 #!/bin/sh -x
 
 echo "I: Remove unneeded files from /usr/share/doc "
-find binary/boot/filesystem.dir/usr/share/doc -print0 -depth -type f ! -name copyright|xargs -0 rm -f || true
-find binary/boot/filesystem.dir/usr/share/doc -print0 -empty|xargs -0 rmdir || true
+find binary/boot/filesystem.dir/usr/share/doc -depth -type f ! -name copyright  -print0 | xargs -0 rm -f || true
+find binary/boot/filesystem.dir/usr/share/doc -empty  -print0 | xargs -0 rmdir || true
 find binary/boot/filesystem.dir/usr/share/doc -type f -exec gzip -9 {} \;
 
 echo "I: Remove man/info pages"
@@ -15,7 +15,7 @@ rm -rf binary/boot/filesystem.dir/usr/share/man \
     
 
 echo "I: Removing /var/lib/apt/lists/*"
-find binary/boot/filesystem.dir/var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
+find binary/boot/filesystem.dir/var/lib/apt/lists/ -type f -print0 | xargs -0 rm -f
 
 echo "I: Removing /var/cache/apt/*.bin"
 rm -f binary/boot/filesystem.dir/var/cache/apt/*.bin

--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -14,7 +14,7 @@ if [ "$(dpkg --print-architecture)" = "amd64" ]; then
     apt-get -y install libc6:i386
 
     echo "I: Removing /var/lib/apt/lists/*"
-    find /var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
+    find /var/lib/apt/lists/ -type f -print0 | xargs -0 rm -f
 
     echo "I: Removing /var/cache/apt/*.bin"
     rm -f /var/cache/apt/*.bin


### PR DESCRIPTION
The order of find is critical for it to work correctly. Each item
after the starting point is evaluated and the resulting return is
used to consider if the term should continue or not. This means
that: "find ./foo -print0 -type f" will *always* call -print0
(and return an implicit "true") and then move on to the "-type f"
test which will return false and the processing will stop for
the given file. So to make things work correctly we need to
write it in the right order as find just evaluates expressions.