### PR TITLE
Support for armhf binaries on arm64 (aarch64) operating system

### DIFF
--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -32,7 +32,7 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     apt-get -y install libc6:armhf
 
     echo "I: Removing /var/lib/apt/lists/*"
-    find /var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
+    find /var/lib/apt/lists/ -type f -print0 | xargs -0 rm -f
 
     echo "I: Removing /var/cache/apt/*.bin"
     rm -f /var/cache/apt/*.bin

--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -19,3 +19,22 @@ if [ "$(dpkg --print-architecture)" = "amd64" ]; then
     echo "I: Removing /var/cache/apt/*.bin"
     rm -f /var/cache/apt/*.bin
 fi
+
+echo "I: Checking if we are arm64 and libc6:armhf should be installed"
+
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    echo "I: Enabling armhf multiarch support on arm64"
+    dpkg --add-architecture armhf
+
+    apt-get -y update
+
+    echo "I: Installing libc6:armhf in arm64 image"
+    apt-get -y install libc6:armhf
+
+    echo "I: Removing /var/lib/apt/lists/*"
+    find /var/lib/apt/lists/ -print0 -type f | xargs -0 rm -f
+
+    echo "I: Removing /var/cache/apt/*.bin"
+    rm -f /var/cache/apt/*.bin
+fi
+


### PR DESCRIPTION
This patch will allow armhf binaries to run on an arm64 (aarch64) operating system by installing the libc6;armhf libraries to the core snap.

Confirmed it works and builds successfully on an arm64 os (Armbian)

it is analogous to patch for running i386 binaries on amd64 operating systems and duplicates that logic so there could be some refactoring to de-dupe, but not necessary for it to work