### PR TITLE
10-remove-documentation: preserve changelogs

### DIFF
--- a/live-build/hooks/10-remove-documentation.binary
+++ b/live-build/hooks/10-remove-documentation.binary
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 echo "I: Remove unneeded files from /usr/share/doc "
-find binary/boot/filesystem.dir/usr/share/doc -depth -type f ! -name copyright  -print0 | xargs -0 rm -f || true
+find binary/boot/filesystem.dir/usr/share/doc -depth -type f ! -name copyright ! -name changelog.gz ! -name changelog.Debian.gz  -print0 | xargs -0 rm -f || true
 find binary/boot/filesystem.dir/usr/share/doc -empty  -print0 | xargs -0 rmdir || true
 find binary/boot/filesystem.dir/usr/share/doc -type f -exec gzip -9 {} \;
 


### PR DESCRIPTION
The changelogs in the /usr/share/doc directories are useful when
generating the changes between two core releases. They are also
pretty tiny. We used to have them but with the bugfix for "find"
(in 009c9ff) the find got pretty aggressive and removed them all.

The root cause for this is that some/many of the livebuild hooks
do not `set -e` - I will do a separate PR for this.