### PR TITLE
ensure that all live-build/hooks run with `set -e`

### DIFF
--- a/live-build/hooks/01-setup_user.chroot
+++ b/live-build/hooks/01-setup_user.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh -x
-
-set -e
+#!/bin/sh -ex
 
 # There is no default user anymore, console-conf is responsible
 # for creating one

--- a/live-build/hooks/03-boot_with_systemd.chroot
+++ b/live-build/hooks/03-boot_with_systemd.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -ex
 
 # Boot using systemd and disable quiet boot
 # to see what is happening.

--- a/live-build/hooks/05-create_minimal_fstab.chroot
+++ b/live-build/hooks/05-create_minimal_fstab.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -ex
 
 cat >>/etc/fstab<<EOT
 # Minimal setup required for systemd to provide a r/w FS

--- a/live-build/hooks/07-configure-system-image-client.chroot
+++ b/live-build/hooks/07-configure-system-image-client.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -ex
 
 # Change default cache partition (until LP: #1373467 is fixed).
 if [ -f /etc/system-image/client.ini ]; then

--- a/live-build/hooks/08-etc-writable.chroot
+++ b/live-build/hooks/08-etc-writable.chroot
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -e
+#!/bin/sh -ex
 
 mkdir -p /etc/writable/default
 

--- a/live-build/hooks/10-remove-documentation.binary
+++ b/live-build/hooks/10-remove-documentation.binary
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -ex
 
 echo "I: Remove unneeded files from /usr/share/doc "
 find binary/boot/filesystem.dir/usr/share/doc -depth -type f ! -name copyright  -print0 | xargs -0 rm -f || true

--- a/live-build/hooks/11-remove-extra-packages.chroot
+++ b/live-build/hooks/11-remove-extra-packages.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 # we want a really minimal image
 apt-get purge -y locales

--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -ex
+#!/bin/sh -ex
 
 echo "I: Checking if we are amd64 and libc6:i386 should be installed"
 

--- a/live-build/hooks/13-set-locale.chroot
+++ b/live-build/hooks/13-set-locale.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 cat >/etc/default/locale<<EOF
 LANG="C.UTF-8"

--- a/live-build/hooks/14-set-motd.chroot
+++ b/live-build/hooks/14-set-motd.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -ex
 
 cat >/etc/motd<<EOF
 Welcome to Snappy Ubuntu Core, a transactionally updated Ubuntu.

--- a/live-build/hooks/15-remove-grub-common.chroot
+++ b/live-build/hooks/15-remove-grub-common.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -ex
 
 # see bug https://bugs.launchpad.net/snappy-ubuntu/+bug/1442231
 rm -f /etc/init.d/grub-common

--- a/live-build/hooks/16-ensure-bootloaders.chroot
+++ b/live-build/hooks/16-ensure-bootloaders.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 mkdir -p /boot/uboot
 cat > /etc/fw_env.config <<EOF

--- a/live-build/hooks/19-remove-cloud-init-locale-test.chroot
+++ b/live-build/hooks/19-remove-cloud-init-locale-test.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 # bug #1637611
 echo "turning /etc/profile.d/Z99-cloud-locale-test.sh into a no-op"

--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -1,6 +1,4 @@
-#! /bin/sh
-
-set -e
+#! /bin/sh -ex
 
 echo "creating mtab and modules dir" >&2
 ln -sf ../proc/self/mounts /etc/mtab

--- a/live-build/hooks/21-snappy-security-policy-stamp.chroot
+++ b/live-build/hooks/21-snappy-security-policy-stamp.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -ex
 #
 # Create the security policy version file. Its important that the file
 # content changes every time an of the "apparmor" or "seccomp" policies
@@ -9,9 +9,6 @@
 # --regenerate-all call. On each boot it will compare the stored version
 # with the version on the image and if they are different regenerate the
 # policies
-
-set -e
-
 
 echo "create security policy version" >&2
 mkdir -p /usr/share/snappy/

--- a/live-build/hooks/22-setup-path.chroot
+++ b/live-build/hooks/22-setup-path.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh -x
-
-set -e
+#!/bin/sh -ex
 
 # Fix the PATH to also contain /snap/bin for non-interactive
 # ssh shells LP: #1659719

--- a/live-build/hooks/25-create-generic-initrd.chroot
+++ b/live-build/hooks/25-create-generic-initrd.chroot
@@ -1,6 +1,4 @@
-#! /bin/sh
-
-set -ex
+#! /bin/sh -ex
 
 IVER="$(dpkg -s initramfs-tools-ubuntu-core | \
 			sed -n '/^Version:/{s/^[^: ]*: \([^: ]*\).*/\1/;p;}')"

--- a/live-build/hooks/26-fixup-core.chroot
+++ b/live-build/hooks/26-fixup-core.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 echo "Setting snapd.core-fixup.service symlink"
 ln -s /lib/systemd/system/snapd.core-fixup.service /lib/systemd/system/multi-user.target.wants/snapd.core-fixup.service

--- a/live-build/hooks/27-systemd-defaults.chroot
+++ b/live-build/hooks/27-systemd-defaults.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 # Fix default handling of secondary interfaces, see LP: #1721223 for
 # details.

--- a/live-build/hooks/30-fix-timedatectl.chroot
+++ b/live-build/hooks/30-fix-timedatectl.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 mv /usr/bin/timedatectl /usr/bin/timedatectl.real
 

--- a/live-build/hooks/300-create-classic-diff.binary
+++ b/live-build/hooks/300-create-classic-diff.binary
@@ -1,8 +1,6 @@
-#! /bin/sh
+#! /bin/sh -ex
 #
 # create delta tarball for classic shell
-
-set -ex
 
 echo "I: Creating delta tarball for use with classic shell"
 

--- a/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
+++ b/live-build/hooks/40-cloud-init-run-after-networkd-wait-online.chroot
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -ex
 
 # Ensure cloud-init runs after networkd-wait-online.service since Ubuntu Core uses networkd
 CI_SERVICE=/lib/systemd/system/cloud-init.service

--- a/live-build/hooks/400-create-apt-get-warning.binary
+++ b/live-build/hooks/400-create-apt-get-warning.binary
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -ex
+#!/bin/sh -ex
 
 echo "I: Creating warning to use snappy when apt-get is used"
 

--- a/live-build/hooks/500-create-xdg.binary
+++ b/live-build/hooks/500-create-xdg.binary
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -ex
+#!/bin/sh -ex
 
 echo "I: Creating xdg helper"
 

--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -1,8 +1,6 @@
-#!/bin/sh
+#!/bin/sh -ex
 #
 # removing debian packaging artifacts
-
-set -ex
 
 echo "I: Removing the debian legacy"
 

--- a/live-build/hooks/700-classic-dir.binary
+++ b/live-build/hooks/700-classic-dir.binary
@@ -1,8 +1,6 @@
-#!/bin/sh
+#!/bin/sh -ex
 #
 # create hostfs entry
-
-set -ex
 
 echo "I: Adding var/lib/snapd/hostfs"
 

--- a/live-build/hooks/99zz-check-uid-gid.chroot
+++ b/live-build/hooks/99zz-check-uid-gid.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -eux
 
 ERRCNT=""
 


### PR DESCRIPTION
It turns out that some scripts did not use `set -e` which lead to some scripts being buggy for a long time (e.g. 10-remove-documentation.binary). This PR ensures we add it everywhere.

Please do not merge just yet, we need to build one more core today and this may break the build (or not, we don't know).