### PR TITLE
hooks: update the set-motd hook to provide better motd

### DIFF
--- a/live-build/hooks/14-set-motd.chroot
+++ b/live-build/hooks/14-set-motd.chroot
@@ -1,12 +1,20 @@
 #!/bin/sh
 
 cat >/etc/motd<<EOF
-Welcome to Snappy Ubuntu Core, a transactionally updated Ubuntu.
 
- * See https://ubuntu.com/snappy
+Welcome to Ubuntu Core, a transactionally updated Ubuntu.
 
-It's a brave new world here in Snappy Ubuntu Core! This machine
-does not use apt-get or deb packages. Please see 'snap --help'
-for app installation and transactional updates.
+ * Ubuntu Core:    https://www.ubuntu.com/core
+ * Documentation:  https://developer.ubuntu.com/core
+
+ * Snaps:          https://snapcraft.io
+ * Support:        https://forum.snapcraft.io
+
+It's a brave new world here in Ubuntu Core! This machine does
+not use apt-get or deb packages. Please see 'snap --help' for
+app installation and transactional updates.
 
 EOF
+
+# remove update-motd bits which clash with /etc/motd content
+rm /etc/update-motd.d/*


### PR DESCRIPTION
It has been observed that the motd displayed when the ssh connection to
Ubuntu Core has been established contains inaccurate and desktop-centric
information, such as:

Welcome to Ubuntu Core 16 (GNU/Linux 4.1.29-g8050069-dirty armv7l)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage
Welcome to Snappy Ubuntu Core, a transactionally updated Ubuntu.

 * See https://ubuntu.com/snappy

It's a brave new world here in Snappy Ubuntu Core! This machine
does not use apt-get or deb packages. Please see 'snap --help'
for app installation and transactional updates.

This commit fixes it by correcting the /etc/motd content to match the
current naming scheme (Snappy Core -> Core) and provide correct
documentation links. Moreover it removes files which are used by
update-motd to generate the dynamic motd.