### PR TITLE
15-remove-grub-common.chroot: skip the first line in grub-common.list

### DIFF
--- a/live-build/hooks/15-remove-grub-common.chroot
+++ b/live-build/hooks/15-remove-grub-common.chroot
@@ -5,7 +5,8 @@ rm -f /etc/init.d/grub-common
 
 echo "removing contents of grub-common except grub-editenv"
 if [ -e /var/lib/dpkg/info/grub-common.list ]; then
-  cat /var/lib/dpkg/info/grub-common.list | while read -r line; do
+  # skip the first line ("/.")
+  tail -n+2 /var/lib/dpkg/info/grub-common.list | while read -r line; do
     if ! echo "$line" | grep -q bin/grub-editenv; then
         rm -f "$line"
     fi


### PR DESCRIPTION
It contains "/." which cannot be removed.