### PR TITLE
xdg-open: add implementation capable of opening local files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
   - sudo sed -i '/^deb/s/$/ universe/' $CHROOT/etc/apt/sources.list
   - sudo chroot $CHROOT apt update
   - sudo chroot $CHROOT apt install -y livecd-rootfs snapcraft
-  - sudo cp -a Makefile snapcraft.yaml hooks live-build $CHROOT/build
+  - sudo cp -a Makefile snapcraft.yaml hooks live-build xdg-open $CHROOT/build
 script:
   - sudo chroot $CHROOT sh -c 'mount -t proc proc /proc; mount -t sysfs sys /sys; cd build; snapcraft'

--- a/live-build/hooks/500-create-xdg.binary
+++ b/live-build/hooks/500-create-xdg.binary
@@ -5,40 +5,6 @@ echo "I: Creating xdg helper"
 PREFIX=binary/boot/filesystem.dir
 
 mkdir -p $PREFIX/usr/bin
-cat >$PREFIX/usr/bin/xdg-open <<EOF
-#!/bin/sh
-if ! dbus-send --print-reply --session --dest=io.snapcraft.Launcher /io/snapcraft/Launcher io.snapcraft.Launcher.OpenURL string:"\$1"; then
-   # compat
-   dbus-send --print-reply --session --dest=com.canonical.SafeLauncher / com.canonical.SafeLauncher.OpenURL string:"\$1"
-fi
-EOF
-chmod 755 $PREFIX/usr/bin/xdg-open
-
-# corresponding .desktop entry, needed for mimetype registration
-mkdir -p $PREFIX/usr/share/applications
-cat >$PREFIX/usr/share/applications/xdg-open.desktop <<EOF
-[Desktop Entry]
-Version=1.0
-Name=Url Handler Script
-Exec=/usr/bin/xdg-open %u
-MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
-Type=Application
-EOF
-
-# define xdg-open as the default handler for common types
-cat >$PREFIX/usr/share/applications/mimeapps.list <<EOF
-[Added Associations]
-x-scheme-handler/http=xdg-open.desktop
-x-scheme-handler/https=xdg-open.desktop
-x-scheme-handler/mailto=xdg-open.desktop
-x-scheme-handler/help=xdg-open.desktop
-
-[Default Applications]
-x-scheme-handler/http=xdg-open.desktop
-x-scheme-handler/https=xdg-open.desktop
-x-scheme-handler/mailto=xdg-open.desktop
-x-scheme-handler/help=xdg-open.desktop
-EOF
 
 cat >$PREFIX/usr/bin/xdg-settings <<'EOF'
 #!/bin/bash

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,3 +31,11 @@ parts:
       - livecd-rootfs
       - shellcheck
       - gawk
+
+  xdg-open:
+    source: xdg-open
+    plugin: make
+    build-packages:
+      - gcc
+      - pkg-config
+      - libglib2.0-dev

--- a/xdg-open/Makefile
+++ b/xdg-open/Makefile
@@ -1,0 +1,22 @@
+
+CC = gcc
+INSTALL = install
+
+CFLAGS = -O2 -g -Wall $(shell pkg-config --cflags gio-unix-2.0)
+LDFLAGS = -O2 -g
+LIBS = $(shell pkg-config --libs gio-2.0)
+
+DESTDIR ?=
+
+all: xdg-open
+
+xdg-open: xdg-open.o
+	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+install: all
+	$(INSTALL) -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/share/applications
+	$(INSTALL) -m 755 -s xdg-open $(DESTDIR)/usr/bin
+	$(INSTALL) -m 644 xdg-open.desktop $(DESTDIR)/usr/share/applications
+	$(INSTALL) -m 644 mimeapps.list $(DESTDIR)/usr/share/applications
+
+.PHONY: all install

--- a/xdg-open/Makefile
+++ b/xdg-open/Makefile
@@ -14,7 +14,7 @@ xdg-open: xdg-open.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 install: all
-	$(INSTALL) -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/share/applications
+	$(INSTALL) -m 755 -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/share/applications
 	$(INSTALL) -m 755 -s xdg-open $(DESTDIR)/usr/bin
 	$(INSTALL) -m 644 xdg-open.desktop $(DESTDIR)/usr/share/applications
 	$(INSTALL) -m 644 mimeapps.list $(DESTDIR)/usr/share/applications

--- a/xdg-open/mimeapps.list
+++ b/xdg-open/mimeapps.list
@@ -1,0 +1,5 @@
+[Default Applications]
+x-scheme-handler/http=xdg-open.desktop
+x-scheme-handler/https=xdg-open.desktop
+x-scheme-handler/mailto=xdg-open.desktop
+x-scheme-handler/help=xdg-open.desktop

--- a/xdg-open/xdg-open.c
+++ b/xdg-open/xdg-open.c
@@ -41,13 +41,14 @@ int main(int argc, char **argv)
         // fd_list takes ownership of the file descriptor
         g_autoptr(GUnixFDList) fd_list = g_unix_fd_list_new_from_array(&fd, 1);
         fd = -1;
-        const int fd_index = 0;
 
+        const char *parent_window = "";
+        const int fd_index = 0;
         result = g_dbus_connection_call_with_unix_fd_list_sync(
             bus,
             "io.snapcraft.Launcher", "/io/snapcraft/Launcher",
             "io.snapcraft.Launcher", "OpenFile",
-            g_variant_new("(h)", fd_index), NULL,
+            g_variant_new("(sh)", parent_window, fd_index), NULL,
             G_DBUS_CALL_FLAGS_NONE, -1, fd_list, NULL, NULL, &error);
     } else {
         g_autofree char *uri = g_file_get_uri(file);

--- a/xdg-open/xdg-open.c
+++ b/xdg-open/xdg-open.c
@@ -1,0 +1,69 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        g_printerr("usage: xdg-open { file | URL }\n");
+        return 1;
+    }
+
+    g_autoptr(GFile) file = g_file_new_for_commandline_arg(argv[1]);
+    if (!file) {
+        g_printerr("could not parse file name or URL\n");
+        return 1;
+    }
+
+    g_autoptr(GError) error = NULL;
+    g_autoptr(GDBusConnection) bus = g_bus_get_sync(
+        G_BUS_TYPE_SESSION, NULL, &error);
+    if (!bus) {
+        g_printerr("could not connect to session bus: %s\n", error->message);
+        return 1;
+    }
+
+    g_autoptr(GVariant) result = NULL;
+    if (g_file_is_native(file)) {
+        g_autofree char *path = g_file_get_path(file);
+
+        int fd = open(path, O_RDONLY | O_CLOEXEC);
+        if (fd == -1) {
+            g_printerr("could not open file: %s\n", g_strerror(errno));
+            return 1;
+        }
+
+        // fd_list takes ownership of the file descriptor
+        g_autoptr(GUnixFDList) fd_list = g_unix_fd_list_new_from_array(&fd, 1);
+        fd = -1;
+        const int fd_index = 0;
+
+        result = g_dbus_connection_call_with_unix_fd_list_sync(
+            bus,
+            "io.snapcraft.Launcher", "/io/snapcraft/Launcher",
+            "io.snapcraft.Launcher", "OpenFile",
+            g_variant_new("(h)", fd_index), NULL,
+            G_DBUS_CALL_FLAGS_NONE, -1, fd_list, NULL, NULL, &error);
+    } else {
+        g_autofree char *uri = g_file_get_uri(file);
+
+        result = g_dbus_connection_call_sync(
+            bus,
+            "io.snapcraft.Launcher", "/io/snapcraft/Launcher",
+            "io.snapcraft.Launcher", "OpenURL",
+            g_variant_new("(s)", uri), NULL,
+            G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+    }
+
+    if (!result) {
+        g_printerr("failed to launch: %s\n", error->message);
+        return 1;
+    }
+
+    return 0;
+}

--- a/xdg-open/xdg-open.desktop
+++ b/xdg-open/xdg-open.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Version=1.0
+Name=Url Handler Script
+Exec=/usr/bin/xdg-open %u
+MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
+Type=Application


### PR DESCRIPTION
This PR is the core snap complement to https://github.com/snapcore/snapd/pull/4766

It replaces the xdg-open proxy to call the new `OpenFile` D-Bus method if a local file is passed as an argument.

Since `OpenFile` expects a file descriptor as proof of access, the `dbus-send` was no longer usable.  So I've replaced it with a C implementation using glib/gio's D-Bus implementation.