### PR TITLE
hooks: create compat copy of /lib/udev/snappy-app-dev

### DIFF
--- a/live-build/hooks/26-fixup-core.chroot
+++ b/live-build/hooks/26-fixup-core.chroot
@@ -5,3 +5,7 @@ ln -s /lib/systemd/system/snapd.core-fixup.service /lib/systemd/system/multi-use
 
 echo "Setting snap-repair.timer symlink"
 ln -s /lib/systemd/system/snapd.snap-repair.timer /lib/systemd/system/timers.target.wants/snapd.snap-repair.timer
+
+echo "Creating compat copy of snappy-app-dev"
+rm -f /lib/udev/snappy-app-dev
+cp -a /usr/lib/snapd/snap-device-helper /lib/udev/snappy-app-dev


### PR DESCRIPTION
This creates a compatibility copy /usr/lib/snapd/snap-device-helper
to /lib/udev/snappy-app-dev so that an old snap-confine will work
correctly with a new core snap. The snappy-app-dev binary got
renamed and while we provided a symlink this is not sufficient
because the apparmor profile for snap-confine does only allow
running /lib/udev/snappy-app-dev.