### PR TITLE
hooks: fix 30-fix-timedatectl.chroot to DTRT when running on non-core devices

### DIFF
--- a/live-build/hooks/30-fix-timedatectl.chroot
+++ b/live-build/hooks/30-fix-timedatectl.chroot
@@ -21,6 +21,14 @@ case $1 in
         # writing here in case of a power loss midway through
         ln -s /usr/share/zoneinfo/"$2" /etc/writable/localtime.tmp
         mv /etc/writable/localtime.tmp /etc/writable/localtime
+        # do special handling on core devices (there /etc/localtime
+        # is a symlink to /etc/writable/localtime)
+        if [ -L /etc/writable/localtime ]; then
+            # make a .tmp link and mv it to have "kind of" atomic
+            # writing here in case of a power loss midway through
+            ln -s /usr/share/zoneinfo/$2 /etc/writable/localtime.tmp
+            mv /etc/writable/localtime.tmp /etc/writable/localtime
+        fi
         ;;
     *)
         $TIMEDATECTL "$@"


### PR DESCRIPTION
This should fix the errors we see when running timedatectl from a snap when running on classic, e.g:  https://github.com/snapcore/snapd/pull/5405