### PR TITLE
hooks: fix silly copy/paste error from PR#89

### DIFF
--- a/live-build/hooks/30-fix-timedatectl.chroot
+++ b/live-build/hooks/30-fix-timedatectl.chroot
@@ -17,10 +17,6 @@ TIMEDATECTL=/usr/bin/timedatectl.real
 case $1 in
     set-timezone)
         $TIMEDATECTL set-timezone "$2"
-        # make a .tmp link and mv it to have "kind of" atomic
-        # writing here in case of a power loss midway through
-        ln -s /usr/share/zoneinfo/"$2" /etc/writable/localtime.tmp
-        mv /etc/writable/localtime.tmp /etc/writable/localtime
         # do special handling on core devices (there /etc/localtime
         # is a symlink to /etc/writable/localtime)
         if [ -L /etc/writable/localtime ]; then


### PR DESCRIPTION
This fixes a rather silly copy/paste issue the symlink handling was done twice.