### PR TITLE
hooks: add a check to ensure that the image is build with ppa:snappy-dev/image

### DIFF
--- a/live-build/hooks/02-check-package-env.chroot
+++ b/live-build/hooks/02-check-package-env.chroot
@@ -1,0 +1,9 @@
+#!/bin/sh -ex
+
+echo "Ensure the project is build with the ppa:snappy-dev/image PPA"
+if ! apt-cache policy ubuntu-core-config|grep ppa.launchpad.net/snappy-dev/image; then
+    echo "The ppa:snappy-dev/image PPA is missing."
+    echo "This probably means that the build was triggered incorrectly."
+    apt-cache policy ubuntu-core-config
+    exit 1
+fi


### PR DESCRIPTION
When triggering a build in LP it is possible to trigger it without
the required lp:snappy-dev/image PPA. This will produce a working
build but the resulting core snap will not work properly and fail
in confusing ways.

This PRs ensures it fails early and in obvious ways.