### PR TITLE
Remove core-support plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,9 +9,6 @@ confinement: strict
 type: os
 grade: stable
 
-hooks:
-  configure:
-
 parts:
   hooks:
     plugin: dump

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,13 +9,8 @@ confinement: strict
 type: os
 grade: stable
 
-plugs:
-  core-support-plug:
-    interface: core-support
-
 hooks:
   configure:
-    plugs: [core-support-plug]
 
 parts:
   hooks:


### PR DESCRIPTION
This patch removes core-support plug from the core snap. Eventually we will be able to remove the interface entirely but for now this is the next best thing.