### PR TITLE
hooks: unwind /etc/alternatives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 dist: xenial
 env:
   global:
-    - URL=http://cdimage.ubuntu.com/ubuntu-base/xenial/daily/current/xenial-base-amd64.tar.gz
+    - URL=http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04-core-amd64.tar.gz
     - CHROOT=xenial-test-chroot
     - LC_ALL=C.UTF-8
     - LANG=C.UTF-8

--- a/live-build/hooks/91-unwind-alternatives.chroot
+++ b/live-build/hooks/91-unwind-alternatives.chroot
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+# undo all symlinks to /etc/alternatives and replace with their real
+# counterparts. The alternatives system looks like this:
+#
+# /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
+#
+find /etc/alternatives -type l | while read -r f; do
+    real=$(readlink -f "$f")
+    alias=$(dirname "$real")/$(basename "$f")
+    rm -f "$alias"
+    ln -s "$real" "$alias"
+done
+# remove all content but keep mount point for compatbility
+rm -rf /etc/alternatives/*
+

--- a/live-build/hooks/91-unwind-alternatives.chroot
+++ b/live-build/hooks/91-unwind-alternatives.chroot
@@ -8,7 +8,14 @@ set -e
 # /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
 #
 find /etc/alternatives -type l | while read -r f; do
-    real=$(readlink -f "$f")
+    # do not use "-f" here to avoid resolving too much, e.g. there is:
+    #    /usr/bin/x-www-browser ->
+    #    /etc/alternatives/x-www-browser ->
+    #    /usr/bin/firefox ->
+    #    ../lib/firefox/firefox.sh
+    # but here we only want to resolv to /usr/bin/firefox not all the
+    # way to the symlink that /usr/bin/firefox points to.
+    real=$(readlink "$f")
     alias=$(dirname "$real")/$(basename "$f")
     rm -f "$alias"
     ln -s "$real" "$alias"


### PR DESCRIPTION
The core snap currently ships with a bunch of files pointing to
/etc/alternatives. E.g.

    /usr/bin/awk -> /etc/alternatives/awk -> /usr/bin/gawk

This is problematic because /etc is mounted from the host so
a user how configured a different awk which is not part of
core will have a dangling symlink (because /usr comes from
the core snap of course).

There is a small risk with this PR as it changes the existing
behaviour. However I would argue its worth it because the
current "awk" that you get in the core snap depends on the
host you run your snap in. Which is not the predictable
behaviour we want.