### PR TITLE
hooks: improve /etc/alternatives unwinding

### DIFF
--- a/live-build/hooks/91-unwind-alternatives.chroot
+++ b/live-build/hooks/91-unwind-alternatives.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -7,19 +7,23 @@ set -e
 #
 # /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
 #
-find /etc/alternatives -type l | while read -r f; do
-    # do not use "-f" here to avoid resolving too much, e.g. there is:
-    #    /usr/bin/x-www-browser ->
-    #    /etc/alternatives/x-www-browser ->
-    #    /usr/bin/firefox ->
-    #    ../lib/firefox/firefox.sh
-    # but here we only want to resolv to /usr/bin/firefox not all the
-    # way to the symlink that /usr/bin/firefox points to.
-    real=$(readlink "$f")
-    alias=$(dirname "$real")/$(basename "$f")
-    rm -f "$alias"
-    ln -s "$real" "$alias"
+# Do this by:
+# 1. find symlinks "f" into /etc/alternatives/
+#    e.g. /usr/bin/pager -> /etc/alternatives/pager
+# 2. get the symlink "target" of the links
+#    e.g. /etc/alternatives/pager -> /bin/less
+# 3. link original symlink "f" directly to target of alternatives,
+#    e.g. /usr/bin/pager -> /bin/less
+find / -xdev -type l | while read -r f; do
+    target=$(readlink "$f")
+    if [[ "$target" == /etc/alternatives/* ]]; then
+        real=$(readlink "$target")
+        echo "unwinding alternatives $real -> $f"
+        rm -f "$f"
+        ln -s "$real" "$f"
+    fi
 done
-# remove all content but keep mount point for compatbility
-rm -rf /etc/alternatives/*
+# and do the final cleanup
+rm -rf /etc/alternatives
+
 


### PR DESCRIPTION
The previous approach of unwinding alternatives had the problem
that e.g. /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
would end up with a "/bin/pager".

This PR fixes this bug. It also splits the alternatives finding
into its own hook script.