### PR TITLE
snapcraft.yaml: add check for ppa:snappy-dev/image

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
   check:
     plugin: dump
     override-pull: |
-      if ! apt-cache policy ubuntu-core-config|grep ppa.launchpad.net/snappy-dev/image; then
+      if ! apt-cache policy ubuntu-core-config|grep -q ppa.launchpad.net/snappy-dev/image; then
           echo "The ppa:snappy-dev/image PPA is missing."
           echo "This probably means that the build was triggered incorrectly."
           apt-cache policy ubuntu-core-config

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,6 +10,16 @@ type: os
 grade: stable
 
 parts:
+  check:
+    plugin: dump
+    override-pull: |
+      if ! apt-cache policy ubuntu-core-config|grep ppa.launchpad.net/snappy-dev/image; then
+          echo "The ppa:snappy-dev/image PPA is missing."
+          echo "This probably means that the build was triggered incorrectly."
+          apt-cache policy ubuntu-core-config
+          exit 1
+      fi
+
   hooks:
     plugin: dump
     source: hooks


### PR DESCRIPTION
Without this PPA things can go very wrong so we need to ensure we
never build a core with that ppa missing.