### PR TITLE
hooks: add /var/lib/jenkins for compat

### DIFF
--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -12,3 +12,7 @@ echo "creating fontconfig mount points" >&2
 mkdir -p /usr/share/fonts
 mkdir -p /usr/local/share/fonts
 mkdir -p /var/cache/fontconfig
+
+# FIXME: this can go once we support non /home dirs directly
+echo "creating jenkins compat home"
+mkdir -p /var/lib/jenkins


### PR DESCRIPTION
The 2.37 release has a regression for people using homedirs in
/var/lib/*. The most prominent example is jenkins. To quickly
unblock that we need this dir and
   https://github.com/snapcore/snapd/pull/6446
and the same for core18.