### PR TITLE
Revert "Merge pull request #100 from mvo5/add-jenkins-dirs"

### DIFF
--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -12,7 +12,3 @@ echo "creating fontconfig mount points" >&2
 mkdir -p /usr/share/fonts
 mkdir -p /usr/local/share/fonts
 mkdir -p /var/cache/fontconfig
-
-# FIXME: this can go once we support non /home dirs directly
-echo "creating jenkins compat home"
-mkdir -p /var/lib/jenkins


### PR DESCRIPTION
Bind mounting over the /var/lib/jenkins here from the host was covering cases that were not supported even before.

This reverts commit 35082278e27b1939db7294176142dc468f045e14, reversing
changes made to 0ff7b71a345b53463f6281855e23d63f0f130f16.