### PR TITLE
hooks: apt warning should return an error

### DIFF
--- a/live-build/hooks/400-create-apt-get-warning.binary
+++ b/live-build/hooks/400-create-apt-get-warning.binary
@@ -8,6 +8,7 @@ mkdir -p $PREFIX/usr/local/bin
 cat >$PREFIX/usr/local/bin/no-apt <<EOF
 #!/bin/sh
 echo "Ubuntu Core does not use apt-get, see 'snap --help'!"
+exit 1
 EOF
 chmod 755 $PREFIX/usr/local/bin/no-apt
 


### PR DESCRIPTION
Since apt cannot be used on core, it should be an error and the exit return code
should specify as such.