### PR TITLE
extra-file: drop restorecon from sshd-host-keygen

### DIFF
--- a/extra-files/usr/lib/snapd/sshd-host-keygen
+++ b/extra-files/usr/lib/snapd/sshd-host-keygen
@@ -42,11 +42,8 @@ create_key() {
 		printf "%s" "$msg"
 		ssh-keygen -q -f "$file" -N '' "$@"
 		echo
-		if which restorecon >/dev/null 2>&1; then
-			restorecon "$file" "$file.pub"
-		fi
 		ssh-keygen -l -f "$file.pub"
-                sync
+		sync
 	fi
 }
 


### PR DESCRIPTION
There is no restorecon on core (thanks to Maciej). Also fix
whitespace in the following line.