### PR TITLE
extra-files: add /var/home to make snaps work on some distros

### DIFF
--- a/extra-files/var/home/.gitignore
+++ b/extra-files/var/home/.gitignore
@@ -1,0 +1,1 @@
+# just needed to have /var/home in git


### PR DESCRIPTION
Some distros use /var/home instead of the traditional /home.
Until we have support for /home at any location this will help
supporting those distros.