### PR TITLE
writable-paths: make /etc/dbus-1/session.d writable

### DIFF
--- a/extra-files/etc/system-image/writable-paths
+++ b/extra-files/etc/system-image/writable-paths
@@ -82,6 +82,7 @@
 # rfkill dir
 /var/lib/systemd/rfkill                 auto                    persistent  transition  none
 # dbus bus policy
+/etc/dbus-1/session.d                   auto                    persistent  transition  none
 /etc/dbus-1/system.d                    auto                    persistent  transition  none
 /etc/modprobe.d                         auto                    synced      none        none
 /etc/ppp                                auto                    persistent  transition  none


### PR DESCRIPTION
When the `snapd` snap is installed on an Ubuntu Core 16 system, it tries to write dbus configuration to `/etc/dbus-1/session.d`, which is not currently writable.  This PR adds that directory as a writable path.