### PR TITLE
live-build/hooks: add chroot hook to rm cloud-init config file we don't want

### DIFF
--- a/live-build/hooks/93-rm-cloud-init-config.chroot
+++ b/live-build/hooks/93-rm-cloud-init-config.chroot
@@ -1,0 +1,11 @@
+#!/bin/sh -ex
+#
+# delete unnecessary debian configuration file for cloud-init
+
+echo "I: Removing /etc/cloud/cloud.cfg.d/90_dpkg.cfg"
+
+# remove cloud-init file which allows all datasources, eventually we should add
+# a cloud-init configuration which specifies all allowed/known to work/good 
+# datasources, but since snapd will do this automatically after seeding, it's 
+# not critical
+rm /etc/cloud/cloud.cfg.d/90_dpkg.cfg


### PR DESCRIPTION
This configuration file has the following contents:

```
# to update this file, run dpkg-reconfigure cloud-init
datasource_list: [ NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Oracle, Exoscale, RbxCloud, None ]
```

On Ubuntu Core, one cannot run dpkg-reconfigure for one, so the file can never
be modified in practice, and additionally we do not want to allow all possible
datasources under the sun without understanding their use cases in Ubuntu Core.

Note that already on Ubuntu Core, snapd as of 2.45.2 will write a configuration
file zzzz_snapd.cfg taking priority over this file to restrict the set of
datasources to a safe one, so we do not strictly need to delete this file, but
it will be simpler if we don't have this file.

This is the UC16 back-port of https://github.com/snapcore/core20/pull/78
See https://github.com/snapcore/core18/pull/166 for the UC18 version