### PR TITLE
extra-files/writable-paths: make all /var/lib/systemd writable

### DIFF
--- a/extra-files/etc/system-image/writable-paths
+++ b/extra-files/etc/system-image/writable-paths
@@ -59,6 +59,8 @@
 /etc/systemd/system                     auto                    synced      none        none
 /etc/systemd/user                       auto                    synced      none        none
 /etc/systemd/journald.conf.d            auto                    synced      none        none
+/var/lib/systemd                        auto                    persistent  transition  none
+/var/lib/private/systemd                auto                    persistent  transition  none
 # needed for usb tethering
 /var/lib/misc                           auto                    persistent  transition  none
 # walinuxagent
@@ -77,10 +79,6 @@
 /var/lib/snapd                         auto                     synced      none        none
 # udev
 /etc/udev/rules.d                       auto                    persistent  transition  none
-# random seed
-/var/lib/systemd/random-seed            auto                    persistent  transition  none
-# rfkill dir
-/var/lib/systemd/rfkill                 auto                    persistent  transition  none
 # dbus bus policy
 /etc/dbus-1/session.d                   auto                    persistent  transition  none
 /etc/dbus-1/system.d                    auto                    persistent  transition  none

--- a/live-build/hooks/08-etc-writable.chroot
+++ b/live-build/hooks/08-etc-writable.chroot
@@ -19,3 +19,9 @@ for f in system user; do
     mkdir -p /etc/systemd/$f.conf.d
 done
 
+# create systemd dirs
+
+echo "creating extra systemd dirs"
+mkdir -p /var/lib/systemd
+mkdir -p /var/lib/private/systemd
+chmod 700 /var/lib/private


### PR DESCRIPTION
This is needed for enabling linger in systemd.

Essentially a backport of this core18 PR: https://github.com/snapcore/core18/pull/6

CC @zyga 