### PR TITLE
extrafiles/writable-paths: make /etc/default/crda writable

### DIFF
--- a/extra-files/etc/system-image/writable-paths
+++ b/extra-files/etc/system-image/writable-paths
@@ -37,6 +37,8 @@
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none
 /etc/default/keyboard                   auto                    persistent  transition  none
+# for wireless regulatory things
+/etc/default/crda                       auto                    persistent  transition  none
 # apparmor cache is not pregenerated in the image builds
 /etc/apparmor.d/cache                   auto                    persistent  none        none
 # needed by apparmor - use transition since some core apps are


### PR DESCRIPTION
This file is used to manage wireless regulatory domains, so it should be writable to allow setting REGDOMAIN in this file.

It's still unclear which snaps / interfaces should actually manage this file, but that can be handled easily with a system-files interface plug in the meantime, but system-files can't make this file writable so we need writable-paths(5) for that.