### PR TITLE
Add finalrd to core.

### DIFF
--- a/live-build/hooks/12-add-foreign-libc6.chroot
+++ b/live-build/hooks/12-add-foreign-libc6.chroot
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 
+echo "I: Enable finalrd"
+apt-get -y install finalrd
+
 echo "I: Checking if we are amd64 and libc6:i386 should be installed"
 
 if [ "$(dpkg --print-architecture)" = "amd64" ]; then


### PR DESCRIPTION
Finalrd is now available in xenial, but despite seeding in system-image, it is not gaining Task: ubuntu-core, and thus is not getting installed during core builds.

Simply install finalrd in an existing hook, that installs libc6 packages.

core18 & core20 are built differently without livecd-rootfs, thus finalrd in those is installed more normally already.