### PR TITLE
live-build: remove ESM tokens, if any are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 dist: xenial
 env:
   global:
-    - URL=http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04-core-amd64.tar.gz
+    - URL=http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04.6-base-amd64.tar.gz
     - CHROOT=xenial-test-chroot
     - LC_ALL=C.UTF-8
     - LANG=C.UTF-8

--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -26,6 +26,8 @@ PREFIX=binary/boot/filesystem.dir
         usr/bin/dpkg-trigger \
         usr/bin/dpkg-statoverride \
         usr/bin/dpkg-maintscript-helper
+    # remove ESM tokens, if any
+    rm -f etc/apt/sources.list.d/ubuntu-esm.list
     # remove generated locales for packages we do not use
     rm -f usr/share/locale/*/LC_MESSAGES/dpkg*
     rm -f usr/share/locale/*/LC_MESSAGES/libapt*


### PR DESCRIPTION
On ESM enabled builds of core, delete the ESM repository tokens that
could be left behind by new-enough livecd-rootfs from snappy-dev/image
ppa.