### PR TITLE
workflow: add basic smoke test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,3 +32,5 @@ jobs:
           sudo chroot $CHROOT apt install -y livecd-rootfs snapcraft
           sudo cp -a Makefile snapcraft.yaml hooks live-build extra-files $CHROOT/build
           sudo chroot $CHROOT sh -c 'mount -t proc proc /proc; mount -t sysfs sys /sys; cd build; snapcraft'
+          # basic smoke testing
+          unsquashfs -ll core*.snap | grep /usr/lib/snapd/snapd$


### PR DESCRIPTION
Do a very basic check that the snap is valid after the building.
Thanks to Sergio for the suggestion.