### PR TITLE
Copy dpkg.yaml for LP Buildd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ENV := $(SUDO) PROJECT=ubuntu-core SUBPROJECT=system-image IMAGEFORMAT=plain SUI
 ifneq ($(shell apt-cache policy snapd|grep ppa.launchpad.net/snappy-dev/edge),)
 EXTRA_PPAS += snappy-dev/edge
 endif
+CUT_PIPES_VARIABLE := (cut -f2 -d=|cut -f1 -d~|cut -b1-29)
 
 all: check
 	mkdir -p auto
@@ -30,11 +31,11 @@ install:
 	# make sure /tmp in the snap is mode 1777
 	$(SUDO) chmod 1777 binary/boot/filesystem.dir/tmp
 	$(SUDO) mv binary/boot/filesystem.dir/* $(DESTDIR)/
-	# only copy the manifest and dpkg.yaml files if we are in a launchpad buildd
+	# only copy the manifest file if we are in a launchpad buildd
 	if [ -e /build/core ]; then \
-	  $(SUDO) mv livecd.ubuntu-core.manifest /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH).manifest; \
-	  $(SUDO) cp usr/share/snappy/dpkg.yaml /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH).dpkg.yaml; \
-	  ls -l /build/core; \
+	  $(SUDO) mv livecd.ubuntu-core.manifest /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info | $(CUT_PIPES_VARIABLE))_$(DPKG_ARCH).manifest; \
+	  $(SUDO) cp /build/core/parts/livebuild/install/usr/share/snappy/dpkg.yaml /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info | $(CUT_PIPES_VARIABLE))_$(DPKG_ARCH).dpkg.yaml; \
+	  ls -lah /build/core; \
 	fi
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ install:
 	# make sure /tmp in the snap is mode 1777
 	$(SUDO) chmod 1777 binary/boot/filesystem.dir/tmp
 	$(SUDO) mv binary/boot/filesystem.dir/* $(DESTDIR)/
-	# only copy the manifest file if we are in a launchpad buildd
+	# only copy the manifest and dpkg.yaml files if we are in a launchpad buildd
 	if [ -e /build/core ]; then \
 	  $(SUDO) mv livecd.ubuntu-core.manifest /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH).manifest; \
+	  $(SUDO) cp usr/share/snappy/dpkg.yaml /build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH).dpkg.yaml; \
 	  ls -l /build/core; \
 	fi
 


### PR DESCRIPTION
We will need to copy the yaml file in order to be able to gather it from the Buildd output folder.