### PR TITLE
Handle PPAs being served from ppa.launchpadcontent.net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUDO := sudo
 EXTRA_PPAS := snappy-dev/image
 ENV := $(SUDO) PROJECT=ubuntu-core SUBPROJECT=system-image IMAGEFORMAT=plain SUITE=$(RELEASE) ARCH=$(DPKG_ARCH)
 
-ifneq ($(shell apt-cache policy snapd|grep ppa.launchpad.net/snappy-dev/edge),)
+ifneq ($(shell apt-cache policy snapd|grep -E 'ppa\.launchpad(content)?\.net/snappy-dev/edge'),)
 EXTRA_PPAS += snappy-dev/edge
 endif
 

--- a/live-build/hooks/02-check-package-env.chroot
+++ b/live-build/hooks/02-check-package-env.chroot
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 echo "Ensure the project is build with the ppa:snappy-dev/image PPA"
-if ! apt-cache policy ubuntu-core-config|grep ppa.launchpad.net/snappy-dev/image; then
+if ! apt-cache policy ubuntu-core-config|grep -E 'ppa\.launchpad(content)?\.net/snappy-dev/image'; then
     echo "The ppa:snappy-dev/image PPA is missing."
     echo "This probably means that the build was triggered incorrectly."
     apt-cache policy ubuntu-core-config

--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -18,7 +18,7 @@ PREFIX=binary/boot/filesystem.dir
   # fill in ppa information in yaml file
   printf 'package-repositories:\n'
   find etc/apt/ -name \*.list | while IFS= read -r APT; do
-    grep -o "^deb http://ppa.launchpad.net/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+" "$APT" | while read -r ENTRY ; do
+    grep -Eo "^deb https?://ppa\.launchpad(content)?\.net/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+" "$APT" | while read -r ENTRY ; do
       USER=$(echo "$ENTRY" | cut -d/ -f4)
       PPA=$(echo "$ENTRY" | cut -d/ -f5)
       DISTRO=$(echo "$ENTRY" | cut -d/ -f6)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
   check:
     plugin: dump
     override-pull: |
-      if ! apt-cache policy ubuntu-core-config|grep -q ppa.launchpad.net/snappy-dev/image; then
+      if ! apt-cache policy ubuntu-core-config|grep -Eq 'ppa\.launchpad(content)?\.net/snappy-dev/image'; then
           echo "The ppa:snappy-dev/image PPA is missing."
           echo "This probably means that the build was triggered incorrectly."
           apt-cache policy ubuntu-core-config


### PR DESCRIPTION
We now have a new HTTPS-capable domain for public PPAs, namely
ppa.launchpadcontent.net.  Adjust various bits of the build system to
accept that.