### PR TITLE
hooks: mkdir /var/cups to avoid writable mimic creation for snaps using cups

### DIFF
--- a/live-build/hooks/20-extra-files.chroot
+++ b/live-build/hooks/20-extra-files.chroot
@@ -12,3 +12,6 @@ echo "creating fontconfig mount points" >&2
 mkdir -p /usr/share/fonts
 mkdir -p /usr/local/share/fonts
 mkdir -p /var/cache/fontconfig
+
+# workaround for cups interface to prevent creating writable mimics
+mkdir -p /var/cups


### PR DESCRIPTION
Snaps using the cups interface with the cups snap as of snapd 2.55 will create
a bind mount of /run/cups -> /var/cups, which since /var/cups does not exist
will trigger the writable mimic code to create a writable mimic on /var. This
results in a fair amount of extra bind mounts for every directory in /var, so
creating this directory empty in the base snap ensures that no writable mimic
need be created.

Note that this will result in review-tools complaining when this is merged and a
new core is uploaded since a new directory is being added to the base snap,
but this is okay.

Also, we can close this PR if we decide that it's not worth updating core anymore
for this sort of feature since `base: core` snaps should be on the way out...