### PR TITLE
hooks: remove "fuse" from the core snap

### DIFF
--- a/live-build/hooks/600-no-debian.binary
+++ b/live-build/hooks/600-no-debian.binary
@@ -35,8 +35,9 @@ PREFIX=binary/boot/filesystem.dir
 )
 
 # dpkg-deb and dpkg purposefully left behind
+# fuse removed because  of https://github.com/snapcore/snapd/pull/11600
 (cd $PREFIX
-    chroot . dpkg --purge --force-depends apt libapt-inst2.0 libapt-pkg5.0 lsb-release
+    chroot . dpkg --purge --force-depends apt libapt-inst2.0 libapt-pkg5.0 lsb-release fuse
     rm -r \
         var/lib/dpkg \
         var/log/apt


### PR DESCRIPTION
With the introduction of https://github.com/snapcore/snapd/pull/11600
now the `fuse` package is installed on `core`. However we do not
want this. This commit forcefully removes it if it gets installed.

There is also a followup https://github.com/snapcore/snapd/pull/11648
that will downgrade fuse to a recommends.