### PR TITLE
hooks: add empty /etc/default/crda and make writable

### DIFF
--- a/live-build/hooks/08-etc-writable.chroot
+++ b/live-build/hooks/08-etc-writable.chroot
@@ -13,6 +13,10 @@ for f in timezone localtime hostname; do
     ln -s /etc/writable/$f /etc/$f
 done
 
+# make /etc/defaults/crda writable
+touch /etc/default/crda
+ln -s /etc/default/crda /etc/writable/crda
+
 # create systemd override dirs
 for f in system user; do
     echo "I: creating /etc/systemd/$f.conf.d"


### PR DESCRIPTION
Some systems need to set the REGDOMAIN for iw(8). This is done
by providing `/etc/default/crda` as a symlink to
`/etc/writable/crda`.