### PR TITLE
extra-files: add udev rule for snap auto-import

### DIFF
--- a/extra-files/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/extra-files/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,0 +1,3 @@
+# probe for assertions, must run before udisks2
+ACTION=="add", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+    RUN+="/usr/bin/unshare -m /usr/bin/snap auto-import --mount=/dev/%k"


### PR DESCRIPTION
This file has always been shipped by snapd, but we are about to remove
it from there because it causes issues on recent classic systems.

See also: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1966203