### PR TITLE
Makefile: fix version script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install:
 	$(SUDO) mv binary/boot/filesystem.dir/* $(DESTDIR)/
 	# only copy the manifest file if we are in a launchpad buildd
 	set -e ; if [ -e /build/core ]; then \
-	  TARGET_BASENAME=/build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH); \
+	  TARGET_BASENAME=/build/core/core_16-$$(grep ^VERSION= $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH); \
 	  $(SUDO) mv livecd.ubuntu-core.manifest "$${TARGET_BASENAME}".manifest;  \
 	  $(SUDO) cp /build/core/parts/livebuild/install/usr/share/snappy/dpkg.yaml "$${TARGET_BASENAME}".dpkg.yaml; \
 	  ls -lah /build/core; \


### PR DESCRIPTION
This mirrors the fix in https://github.com/snapcore/core/pull/127 but for the target filename instead of for the version scriptlet.

The current `usr/lib/snapd/info` looks like this:
```
VERSION=2.59.3
SNAPD_APPARMOR_REEXEC=1
SNAPD_ASSERTS_FORMATS='{"snap-declaration":5,"system-user":2}'
```
which means that the previous version of the code would extract a version number like:
```
$ cat usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29
2.59.3
1
'{"snap-declaration":5,"syste
```
Using `grep` to just find the right lines fixes this.

This was observed in recent uploads of core, e.g. in https://launchpad.net/~snappy-dev/+snap/core-beta/+build/2098563

Thanks to Colin and Dimitri for their help with this!